### PR TITLE
Clearing dynamical components every frame

### DIFF
--- a/src/laser/mod.rs
+++ b/src/laser/mod.rs
@@ -121,11 +121,6 @@ pub fn add_systems_to_dispatch(builder: &mut DispatcherBuilder<'static, 'static>
 		deps,
 	);
 	builder.add(
-		photons_scattered::InitialiseActualPhotonsScatteredVectorSystem,
-		"initialise_actual_photons",
-		deps,
-	);
-	builder.add(
 		rate::InitialiseRateCoefficientsSystem,
 		"initialise_rate_coefficients",
 		deps,
@@ -185,7 +180,7 @@ pub fn add_systems_to_dispatch(builder: &mut DispatcherBuilder<'static, 'static>
 	builder.add(
 		photons_scattered::CalculateActualPhotonsScatteredSystem,
 		"calculate_actual_photons",
-		&["calculate_expected_photons", "initialise_actual_photons"],
+		&["calculate_expected_photons"],
 	);
 	builder.add(
 		force::CalculateAbsorptionForcesSystem,

--- a/src/laser/mod.rs
+++ b/src/laser/mod.rs
@@ -111,6 +111,26 @@ pub fn add_systems_to_dispatch(builder: &mut DispatcherBuilder<'static, 'static>
 		deps,
 	);
 	builder.add(
+		intensity::InitialiseLaserIntensitySamplersSystem,
+		"initialise_laser_intensity",
+		deps,
+	);
+	builder.add(
+		photons_scattered::InitialiseExpectedPhotonsScatteredVectorSystem,
+		"initialise_expected_photons",
+		deps,
+	);
+	builder.add(
+		photons_scattered::InitialiseActualPhotonsScatteredVectorSystem,
+		"initialise_actual_photons",
+		deps,
+	);
+	builder.add(
+		rate::InitialiseRateCoefficientsSystem,
+		"initialise_rate_coefficients",
+		deps,
+	);
+	builder.add(
 		sampler::FillLaserSamplerMasksSystem,
 		"fill_laser_sampler_masks",
 		&["index_cooling_lights", "initialise_laser_sampler_masks"],
@@ -118,7 +138,11 @@ pub fn add_systems_to_dispatch(builder: &mut DispatcherBuilder<'static, 'static>
 	builder.add(
 		intensity::SampleLaserIntensitySystem,
 		"sample_laser_intensity",
-		&["index_cooling_lights", INTEGRATE_POSITION_SYSTEM_NAME],
+		&[
+			"index_cooling_lights",
+			"initialise_laser_intensity",
+			INTEGRATE_POSITION_SYSTEM_NAME,
+		],
 	);
 	builder.add(
 		doppler::CalculateDopplerShiftSystem,
@@ -137,7 +161,7 @@ pub fn add_systems_to_dispatch(builder: &mut DispatcherBuilder<'static, 'static>
 	builder.add(
 		rate::CalculateRateCoefficientsSystem,
 		"calculate_rate_coefficients",
-		&["calculate_laser_detuning"],
+		&["initialise_rate_coefficients", "calculate_laser_detuning"],
 	);
 	builder.add(
 		twolevel::CalculateTwoLevelPopulationSystem,
@@ -152,12 +176,16 @@ pub fn add_systems_to_dispatch(builder: &mut DispatcherBuilder<'static, 'static>
 	builder.add(
 		photons_scattered::CalculateExpectedPhotonsScatteredSystem,
 		"calculate_expected_photons",
-		&["calculate_total_photons", "fill_laser_sampler_masks"],
+		&[
+			"calculate_total_photons",
+			"fill_laser_sampler_masks",
+			"initialise_expected_photons",
+		],
 	);
 	builder.add(
 		photons_scattered::CalculateActualPhotonsScatteredSystem,
 		"calculate_actual_photons",
-		&["calculate_expected_photons"],
+		&["calculate_expected_photons", "initialise_actual_photons"],
 	);
 	builder.add(
 		force::CalculateAbsorptionForcesSystem,

--- a/src/laser/photons_scattered.rs
+++ b/src/laser/photons_scattered.rs
@@ -220,21 +220,6 @@ impl Component for ActualPhotonsScatteredVector {
     type Storage = VecStorage<Self>;
 }
 
-/// This system initialises all `ActualPhotonsScatteredVector` to a NAN value.
-///
-/// It also ensures that the size of the `ActualPhotonsScatteredVector` components match the number of CoolingLight entities in the world.
-pub struct InitialiseActualPhotonsScatteredVectorSystem;
-impl<'a> System<'a> for InitialiseActualPhotonsScatteredVectorSystem {
-    type SystemData = (WriteStorage<'a, ActualPhotonsScatteredVector>,);
-    fn run(&mut self, (mut actual_photons,): Self::SystemData) {
-        use rayon::prelude::*;
-
-        (&mut actual_photons).par_join().for_each(|mut actual| {
-            actual.contents = [ActualPhotonsScattered::default(); crate::laser::COOLING_BEAM_LIMIT];
-        });
-    }
-}
-
 /// If this is added as a resource, the number of actual photons will be drawn from a poisson distribution.
 ///
 /// Otherwise, the entries of `ActualPhotonsScatteredVector` will be identical with those of


### PR DESCRIPTION
I found, that, in the end, somewhere between my original implementation and the current master branch, the Initialization systems have been removed from the master branch... Which caused the dipole trap heating after MOT beams were disabled (because some components still held values != 0) 