### PR TITLE
Updated dependencies and fixed some warning messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 *.xyz
 *.blend
 *.blend1
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,32 +4,20 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.3.8"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
-
-[[package]]
-name = "ahash"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
-
-[[package]]
-name = "alga"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f823d037a7ec6ea2197046bafd4ae150e6bc36f9ca347404f46a46823fa84f2"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "approx",
- "num-complex",
- "num-traits",
+ "getrandom",
+ "once_cell",
+ "version_check",
 ]
 
 [[package]]
 name = "approx"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
+checksum = "072df7202e63b127ab55acfe16ce97013d5b97bf160489336d3f1840fd78e99e"
 dependencies = [
  "num-traits",
 ]
@@ -62,10 +50,10 @@ dependencies = [
  "criterion",
  "csv",
  "gnuplot",
- "hashbrown 0.9.1",
+ "hashbrown",
  "multimap",
  "nalgebra",
- "rand 0.8.4",
+ "rand",
  "rand_distr",
  "rayon",
  "serde",
@@ -97,12 +85,6 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
-
-[[package]]
-name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
@@ -127,9 +109,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.1"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
+
+[[package]]
+name = "bytemuck"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72957246c41db82b8ef88a5486143830adeb8227ef9837740bdec67724cf2c5b"
 
 [[package]]
 name = "byteorder"
@@ -148,34 +136,19 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "bitflags",
  "textwrap",
  "unicode-width",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -220,8 +193,8 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.5",
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -230,9 +203,9 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.5",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -241,8 +214,8 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.5",
+ "cfg-if",
+ "crossbeam-utils",
  "lazy_static",
  "memoffset",
  "scopeguard",
@@ -250,24 +223,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.2.3"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
+checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
 dependencies = [
- "cfg-if 0.1.10",
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg 1.0.1",
- "cfg-if 0.1.10",
- "lazy_static",
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -276,7 +237,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "lazy_static",
 ]
 
@@ -315,68 +276,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
-name = "generic-array"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi",
 ]
 
 [[package]]
 name = "gnuplot"
-version = "0.0.31"
+version = "0.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a907dc810202b800898a3059eba489404c7f232f8e141500122a86b173bd7f"
+checksum = "8de437277a7ec10de5f34e3147c7da4c6d8b279c5d8ae1e33e842fd9432bb0f3"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "half"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac5956d4e63858efaec57e0d6c1c2f6a41e1487f830314a324ccd7e2223a7ca0"
-
-[[package]]
-name = "hashbrown"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96282e96bfcd3da0d3aa9938bedf1e50df3269b6db08b4876d2da0bb1a0841cf"
-dependencies = [
- "ahash 0.3.8",
- "autocfg 1.0.1",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-dependencies = [
- "ahash 0.4.7",
- "rayon",
-]
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+ "rayon",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -403,15 +336,15 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
- "autocfg 1.0.1",
- "hashbrown 0.11.2",
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
@@ -439,9 +372,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.103"
+version = "0.2.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+checksum = "f98a04dce437184842841303488f70d0188c5f51437d2a834dc097eafa909a01"
 
 [[package]]
 name = "libm"
@@ -461,23 +394,17 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
 name = "matrixmultiply"
-version = "0.2.4"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916806ba0031cd542105d916a97c8572e1fa6dd79c9c51e7eb43a09ec2dd84c1"
+checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
 dependencies = [
  "rawpointer",
 ]
-
-[[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
@@ -487,11 +414,11 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -511,21 +438,30 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.18.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaa9fddbc34c8c35dd2108515587b8ce0cab396f17977b8c738568e4edb521a2"
+checksum = "d506eb7e08d6329505faa8a3a00a5dcc6de9f76e0c77e4b75763ae3c770831ff"
 dependencies = [
- "alga",
  "approx",
- "generic-array",
  "matrixmultiply",
+ "nalgebra-macros",
  "num-complex",
  "num-rational",
  "num-traits",
- "rand 0.6.5",
  "serde",
- "serde_derive",
+ "simba",
  "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -540,11 +476,10 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.2.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
 dependencies = [
- "autocfg 1.0.1",
  "num-traits",
  "serde",
 ]
@@ -555,17 +490,17 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-rational"
-version = "0.2.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -576,7 +511,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "libm",
 ]
 
@@ -591,10 +526,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+
+[[package]]
 name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "paste"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 
 [[package]]
 name = "plotters"
@@ -626,15 +573,15 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ca011bd0129ff4ae15cd04c4eef202cadf6c51c21e47aba319b4e0501db741"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.30"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
+checksum = "fb37d2df5df740e582f28f8560cf425f52bb267d872fe58358eadb554909f07a"
 dependencies = [
  "unicode-xid",
 ]
@@ -650,43 +597,14 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-dependencies = [
- "autocfg 0.1.7",
- "libc",
- "rand_chacha 0.1.1",
- "rand_core 0.4.2",
- "rand_hc 0.1.0",
- "rand_isaac",
- "rand_jitter",
- "rand_os",
- "rand_pcg",
- "rand_xorshift",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.3",
- "rand_hc 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.3.1",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
 ]
 
 [[package]]
@@ -696,23 +614,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -730,16 +633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "964d548f8e7d12e102ef183a0de7e98180c9f8729f555897a857b96e48122d2f"
 dependencies = [
  "num-traits",
- "rand 0.8.4",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-dependencies = [
- "rand_core 0.3.1",
+ "rand",
 ]
 
 [[package]]
@@ -748,60 +642,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-dependencies = [
- "rand_core 0.3.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -816,7 +657,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -830,18 +671,9 @@ checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-utils 0.8.5",
+ "crossbeam-utils",
  "lazy_static",
  "num_cpus",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -876,9 +708,18 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
+
+[[package]]
+name = "safe_arch"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794821e4ccb0d9f979512f9c1973480123f9bd62a90d74ab0f9426fcf8f4a529"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -933,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "d0ffa0837f2dfa6fb90868c2b5468cad482e175f7dad97e7421951e663f2b527"
 dependencies = [
  "itoa",
  "ryu",
@@ -956,12 +797,12 @@ dependencies = [
 
 [[package]]
 name = "shred"
-version = "0.10.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f08237e667ac94ad20f8878b5943d91a93ccb231428446c57c21c57779016d"
+checksum = "eb0210289d693217926314867c807e0b7b42f7e23c136adb31f8697f5bf242d3"
 dependencies = [
  "arrayvec",
- "hashbrown 0.7.2",
+ "hashbrown",
  "mopa",
  "rayon",
  "smallvec",
@@ -975,6 +816,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5752e017e03af9d735b4b069f53b7a7fd90fefafa04d8bd0c25581b0bff437f"
 
 [[package]]
+name = "simba"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0b7840f121a46d63066ee7a99fc81dcabbc6105e437cae43528cea199b5a05f"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,12 +836,12 @@ checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "specs"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff28a29366aff703d5da8a7e2c8875dc8453ac1118f842cbc0fa70c7db51240"
+checksum = "5dcc1e4ba7ab1f08ecb3d7e2f693defc3907e2c03bb0924f9978be45b364f83f"
 dependencies = [
  "crossbeam-queue",
- "hashbrown 0.7.2",
+ "hashbrown",
  "hibitset",
  "log",
  "rayon",
@@ -1009,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.80"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1099,7 +953,7 @@ version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -1155,6 +1009,16 @@ checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f2548e954f6619da26c140d020e99e59a2ca872a11f1e6250b829e8c96c893"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0-or-later"
 [dependencies]
 atomecs-derive = { git = "https://github.com/TeamAtomECS/AtomECS-derive" }
 rayon = "1.5.0"
-specs={ version="0.16.1", features=["rayon"] }
+specs={ version="0.17.0", features=["rayon"] }
 specs-derive = "0.4.1"
 rand = "0.8.3"
 rand_distr = "0.4.0"
@@ -16,14 +16,14 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8.9"
 assert_approx_eq = "1.1.0"
-nalgebra = { version = "0.18", features = ["serde-serialize"] }
+nalgebra = { version = "0.29.0", features = ["serde-serialize"] }
 csv = "1.1"
 byteorder = "1.3.2"
 multimap = "0.8.2"
-hashbrown = { version = "0.9.1", features = ["rayon"] }
+hashbrown = { version = "0.11.2", features = ["rayon"] }
 
 [dev-dependencies]
-gnuplot="0.0.31"
+gnuplot="0.0.37"
 criterion = "0.3"
 
 [[bench]]

--- a/examples/quadrupole_trap.rs
+++ b/examples/quadrupole_trap.rs
@@ -88,7 +88,7 @@ fn main() {
     }
 
     // Define timestep
-    world.add_resource(Timestep { delta: 1.0e-5 });
+    world.insert(Timestep { delta: 1.0e-5 });
 
     // Run the simulation for a number of steps.
     for _i in 0..10000 {

--- a/src/atom_sources/central_creator.rs
+++ b/src/atom_sources/central_creator.rs
@@ -349,6 +349,7 @@ pub mod tests {
                 .get(checker1)
                 .expect("entity not found")
                 .everything_allright,
+            "{}",
             true
         );
 

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -13,9 +13,9 @@ use crate::dipole;
 use crate::gravity::ApplyGravitationalForceSystem;
 use crate::initiate::DeflagNewAtomsSystem;
 use crate::integrator::{
-	AddOldForceToNewAtomsSystem, Step, VelocityVerletIntegratePositionSystem,
-	VelocityVerletIntegrateVelocitySystem, INTEGRATE_POSITION_SYSTEM_NAME,
-	INTEGRATE_VELOCITY_SYSTEM_NAME,
+    AddOldForceToNewAtomsSystem, Step, VelocityVerletIntegratePositionSystem,
+    VelocityVerletIntegrateVelocitySystem, INTEGRATE_POSITION_SYSTEM_NAME,
+    INTEGRATE_VELOCITY_SYSTEM_NAME,
 };
 use crate::laser;
 use crate::laser_cooling;
@@ -28,94 +28,92 @@ use specs::prelude::*;
 
 /// Registers all components used by the modules of the program.
 pub fn register_components(world: &mut World) {
-	atom::register_components(world);
-	magnetic::register_components(world);
-	laser::register_components(world);
-	atom_sources::register_components(world);
-	sim_region::register_components(world);
-	world.register::<Dark>();
-	dipole::register_components(world);
+    atom::register_components(world);
+    magnetic::register_components(world);
+    laser::register_components(world);
+    atom_sources::register_components(world);
+    sim_region::register_components(world);
+    world.register::<Dark>();
+    dipole::register_components(world);
 }
 
 /// Struct that creates the ECS Dispatcher builder used in AtomECS.
 pub struct AtomecsDispatcherBuilder {
-	pub builder: DispatcherBuilder<'static, 'static>,
+    pub builder: DispatcherBuilder<'static, 'static>,
 }
 impl AtomecsDispatcherBuilder {
-	pub fn new() -> AtomecsDispatcherBuilder {
-		AtomecsDispatcherBuilder {
-			builder: DispatcherBuilder::new(),
-		}
-	}
+    pub fn new() -> AtomecsDispatcherBuilder {
+        AtomecsDispatcherBuilder {
+            builder: DispatcherBuilder::new(),
+        }
+    }
 
-	pub fn add_frame_initialisation_systems(&mut self) {}
+    pub fn add_frame_initialisation_systems(&mut self) {}
 
-	pub fn add_systems(&mut self) {
-		&self.builder.add(
-			VelocityVerletIntegratePositionSystem,
-			INTEGRATE_POSITION_SYSTEM_NAME,
-			&[],
-		);
-		&self
-			.builder
-			.add(ClearForceSystem, "clear", &[INTEGRATE_POSITION_SYSTEM_NAME]);
-		&self.builder.add(DeflagNewAtomsSystem, "deflag", &[]);
-		&self.builder.add(AddOldForceToNewAtomsSystem, "", &[]);
+    pub fn add_systems(&mut self) {
+        self.builder.add(
+            VelocityVerletIntegratePositionSystem,
+            INTEGRATE_POSITION_SYSTEM_NAME,
+            &[],
+        );
+        self.builder
+            .add(ClearForceSystem, "clear", &[INTEGRATE_POSITION_SYSTEM_NAME]);
+        self.builder.add(DeflagNewAtomsSystem, "deflag", &[]);
+        self.builder.add(AddOldForceToNewAtomsSystem, "", &[]);
 
-		magnetic::add_systems_to_dispatch(&mut self.builder, &[]);
-		laser::add_systems_to_dispatch(&mut self.builder, &[]);
-		laser_cooling::add_systems_to_dispatch(&mut self.builder, &[]);
-		dipole::add_systems_to_dispatch(&mut self.builder, &[]);
-		atom_sources::add_systems_to_dispatch(&mut self.builder, &[]);
-		self.builder.add(
-			ApplyGravitationalForceSystem,
-			"add_gravity",
-			&["clear", INTEGRATE_POSITION_SYSTEM_NAME],
-		);
+        magnetic::add_systems_to_dispatch(&mut self.builder, &[]);
+        laser::add_systems_to_dispatch(&mut self.builder, &[]);
+        laser_cooling::add_systems_to_dispatch(&mut self.builder, &[]);
+        dipole::add_systems_to_dispatch(&mut self.builder, &[]);
+        atom_sources::add_systems_to_dispatch(&mut self.builder, &[]);
+        self.builder.add(
+            ApplyGravitationalForceSystem,
+            "add_gravity",
+            &["clear", INTEGRATE_POSITION_SYSTEM_NAME],
+        );
 
-		&self.builder.add(
-			VelocityVerletIntegrateVelocitySystem,
-			INTEGRATE_VELOCITY_SYSTEM_NAME,
-			&[
-				"calculate_absorption_forces",
-				"calculate_emission_forces",
-				"add_gravity",
-			],
-		);
-	}
+        self.builder.add(
+            VelocityVerletIntegrateVelocitySystem,
+            INTEGRATE_VELOCITY_SYSTEM_NAME,
+            &[
+                "calculate_absorption_forces",
+                "calculate_emission_forces",
+                "add_gravity",
+            ],
+        );
+    }
 
-	pub fn add_frame_end_systems(&mut self) {
-		&self
-			.builder
-			.add(ConsoleOutputSystem, "", &[INTEGRATE_VELOCITY_SYSTEM_NAME]);
-		&self.builder.add(
-			DeleteToBeDestroyedEntitiesSystem,
-			"",
-			&[INTEGRATE_VELOCITY_SYSTEM_NAME],
-		);
-		sim_region::add_systems_to_dispatch(&mut self.builder, &[]);
-	}
+    pub fn add_frame_end_systems(&mut self) {
+        self.builder
+            .add(ConsoleOutputSystem, "", &[INTEGRATE_VELOCITY_SYSTEM_NAME]);
+        self.builder.add(
+            DeleteToBeDestroyedEntitiesSystem,
+            "",
+            &[INTEGRATE_VELOCITY_SYSTEM_NAME],
+        );
+        sim_region::add_systems_to_dispatch(&mut self.builder, &[]);
+    }
 
-	pub fn build(mut self) -> DispatcherBuilder<'static, 'static> {
-		self.add_frame_initialisation_systems();
-		self.add_systems();
-		self.add_frame_end_systems();
-		self.builder
-	}
+    pub fn build(mut self) -> DispatcherBuilder<'static, 'static> {
+        self.add_frame_initialisation_systems();
+        self.add_systems();
+        self.add_frame_end_systems();
+        self.builder
+    }
 }
 
 /// Creates a [Dispatcher](specs::Dispatcher) that is used to calculate each simulation frame.
 pub fn create_simulation_dispatcher() -> Dispatcher<'static, 'static> {
-	let builder = create_simulation_dispatcher_builder();
-	builder.build()
+    let builder = create_simulation_dispatcher_builder();
+    builder.build()
 }
 
 pub fn create_simulation_dispatcher_builder() -> DispatcherBuilder<'static, 'static> {
-	let atomecs_builder = AtomecsDispatcherBuilder::new();
-	atomecs_builder.build()
+    let atomecs_builder = AtomecsDispatcherBuilder::new();
+    atomecs_builder.build()
 }
 
 /// Add required resources to the world
 pub fn register_resources(world: &mut World) {
-	world.insert(Step { n: 0 });
+    world.insert(Step { n: 0 });
 }

--- a/src/integrator.rs
+++ b/src/integrator.rs
@@ -12,7 +12,7 @@ use specs::prelude::*;
 
 /// Tracks the number of the current integration step.
 pub struct Step {
-	pub n: u64,
+    pub n: u64,
 }
 
 /// The timestep used for the integration.
@@ -23,8 +23,8 @@ pub struct Step {
 /// Decreasing the timestep further will not improve the accuracy, and will require more integration steps
 /// to simulate the same total simulation time.
 pub struct Timestep {
-	/// Duration of the simulation timestep, in SI units of seconds.
-	pub delta: f64,
+    /// Duration of the simulation timestep, in SI units of seconds.
+    pub delta: f64,
 }
 
 /// # Euler Integration
@@ -37,25 +37,25 @@ pub struct Timestep {
 pub struct EulerIntegrationSystem;
 
 impl<'a> System<'a> for EulerIntegrationSystem {
-	type SystemData = (
-		WriteStorage<'a, Position>,
-		WriteStorage<'a, Velocity>,
-		ReadExpect<'a, Timestep>,
-		WriteExpect<'a, Step>,
-		ReadStorage<'a, Force>,
-		ReadStorage<'a, Mass>,
-	);
+    type SystemData = (
+        WriteStorage<'a, Position>,
+        WriteStorage<'a, Velocity>,
+        ReadExpect<'a, Timestep>,
+        WriteExpect<'a, Step>,
+        ReadStorage<'a, Force>,
+        ReadStorage<'a, Mass>,
+    );
 
-	fn run(&mut self, (mut pos, mut vel, t, mut step, force, mass): Self::SystemData) {
-		use rayon::prelude::*;
+    fn run(&mut self, (mut pos, mut vel, t, mut step, force, mass): Self::SystemData) {
+        use rayon::prelude::*;
 
-		step.n = step.n + 1;
-		(&mut vel, &mut pos, &force, &mass).par_join().for_each(
-			|(mut vel, mut pos, force, mass)| {
-				euler_update(&mut vel, &mut pos, &force, &mass, t.delta);
-			},
-		);
-	}
+        step.n = step.n + 1;
+        (&mut vel, &mut pos, &force, &mass).par_join().for_each(
+            |(mut vel, mut pos, force, mass)| {
+                euler_update(&mut vel, &mut pos, &force, &mass, t.delta);
+            },
+        );
+    }
 }
 
 pub const INTEGRATE_POSITION_SYSTEM_NAME: &str = "integrate_position";
@@ -68,31 +68,31 @@ pub const INTEGRATE_POSITION_SYSTEM_NAME: &str = "integrate_position";
 /// The timestep duration is specified by the [Timestep](struct.Timestep.html) system resource.
 pub struct VelocityVerletIntegratePositionSystem;
 impl<'a> System<'a> for VelocityVerletIntegratePositionSystem {
-	type SystemData = (
-		WriteStorage<'a, Position>,
-		ReadStorage<'a, Velocity>,
-		ReadExpect<'a, Timestep>,
-		WriteExpect<'a, Step>,
-		ReadStorage<'a, Force>,
-		WriteStorage<'a, OldForce>,
-		ReadStorage<'a, Mass>,
-	);
+    type SystemData = (
+        WriteStorage<'a, Position>,
+        ReadStorage<'a, Velocity>,
+        ReadExpect<'a, Timestep>,
+        WriteExpect<'a, Step>,
+        ReadStorage<'a, Force>,
+        WriteStorage<'a, OldForce>,
+        ReadStorage<'a, Mass>,
+    );
 
-	fn run(&mut self, (mut pos, vel, t, mut step, force, mut oldforce, mass): Self::SystemData) {
-		use rayon::prelude::*;
+    fn run(&mut self, (mut pos, vel, t, mut step, force, mut oldforce, mass): Self::SystemData) {
+        use rayon::prelude::*;
 
-		step.n = step.n + 1;
-		let dt = t.delta;
+        step.n = step.n + 1;
+        let dt = t.delta;
 
-		(&mut pos, &vel, &mut oldforce, &force, &mass)
-			.par_join()
-			.for_each(|(mut pos, vel, mut oldforce, force, mass)| {
-				pos.pos = pos.pos
-					+ vel.vel * dt + force.force / (constant::AMU * mass.value) / 2.0
-					* dt * dt;
-				oldforce.0 = *force;
-			});
-	}
+        (&mut pos, &vel, &mut oldforce, &force, &mass)
+            .par_join()
+            .for_each(|(mut pos, vel, mut oldforce, force, mass)| {
+                pos.pos = pos.pos
+                    + vel.vel * dt
+                    + force.force / (constant::AMU * mass.value) / 2.0 * dt * dt;
+                oldforce.0 = *force;
+            });
+    }
 }
 
 pub const INTEGRATE_VELOCITY_SYSTEM_NAME: &str = "integrate_velocity";
@@ -104,253 +104,253 @@ pub const INTEGRATE_VELOCITY_SYSTEM_NAME: &str = "integrate_velocity";
 /// The timestep duration is specified by the [Timestep](struct.Timestep.html) system resource
 pub struct VelocityVerletIntegrateVelocitySystem;
 impl<'a> System<'a> for VelocityVerletIntegrateVelocitySystem {
-	type SystemData = (
-		WriteStorage<'a, Velocity>,
-		ReadExpect<'a, Timestep>,
-		ReadStorage<'a, Force>,
-		ReadStorage<'a, OldForce>,
-		ReadStorage<'a, Mass>,
-	);
+    type SystemData = (
+        WriteStorage<'a, Velocity>,
+        ReadExpect<'a, Timestep>,
+        ReadStorage<'a, Force>,
+        ReadStorage<'a, OldForce>,
+        ReadStorage<'a, Mass>,
+    );
 
-	fn run(&mut self, (mut vel, t, force, oldforce, mass): Self::SystemData) {
-		use rayon::prelude::*;
+    fn run(&mut self, (mut vel, t, force, oldforce, mass): Self::SystemData) {
+        use rayon::prelude::*;
 
-		let dt = t.delta;
+        let dt = t.delta;
 
-		(&mut vel, &force, &oldforce, &mass).par_join().for_each(
-			|(mut vel, force, oldforce, mass)| {
-				vel.vel = vel.vel
-					+ (force.force + oldforce.0.force) / (constant::AMU * mass.value) / 2.0 * dt;
-			},
-		);
-	}
+        (&mut vel, &force, &oldforce, &mass).par_join().for_each(
+            |(mut vel, force, oldforce, mass)| {
+                vel.vel = vel.vel
+                    + (force.force + oldforce.0.force) / (constant::AMU * mass.value) / 2.0 * dt;
+            },
+        );
+    }
 }
 
 /// Adds [OldForce](OldForce.struct.html) components to newly created atoms.
 pub struct AddOldForceToNewAtomsSystem;
 impl<'a> System<'a> for AddOldForceToNewAtomsSystem {
-	type SystemData = (
-		Entities<'a>,
-		ReadStorage<'a, NewlyCreated>,
-		ReadStorage<'a, OldForce>,
-		Read<'a, LazyUpdate>,
-	);
-	fn run(&mut self, (ent, newly_created, oldforce, updater): Self::SystemData) {
-		for (ent, _, _) in (&ent, &newly_created, !&oldforce).join() {
-			updater.insert(ent, OldForce::default());
-		}
-	}
+    type SystemData = (
+        Entities<'a>,
+        ReadStorage<'a, NewlyCreated>,
+        ReadStorage<'a, OldForce>,
+        Read<'a, LazyUpdate>,
+    );
+    fn run(&mut self, (ent, newly_created, oldforce, updater): Self::SystemData) {
+        for (ent, _, _) in (&ent, &newly_created, !&oldforce).join() {
+            updater.insert(ent, OldForce::default());
+        }
+    }
 }
 
 /// Stores the value of the force calculation from the previous frame.
 pub struct OldForce(Force);
 impl Component for OldForce {
-	type Storage = VecStorage<OldForce>;
+    type Storage = VecStorage<OldForce>;
 }
 impl Default for OldForce {
-	fn default() -> Self {
-		OldForce { 0: Force::new() }
-	}
+    fn default() -> Self {
+        OldForce { 0: Force::new() }
+    }
 }
 
 /// Performs the euler method to update [Velocity](struct.Velocity.html) and [Position](struct.Position.html) given an applied [Force](struct.Force.html).
 fn euler_update(vel: &mut Velocity, pos: &mut Position, force: &Force, mass: &Mass, dt: f64) {
-	pos.pos = pos.pos + vel.vel * dt;
-	vel.vel = vel.vel + force.force * dt / (constant::AMU * mass.value);
+    pos.pos = pos.pos + vel.vel * dt;
+    vel.vel = vel.vel + force.force * dt / (constant::AMU * mass.value);
 }
 
 pub mod tests {
-	#[allow(unused_imports)]
-	use super::*;
-	extern crate specs;
-	#[allow(unused_imports)]
-	use specs::{Builder, DispatcherBuilder, World};
+    #[allow(unused_imports)]
+    use super::*;
+    extern crate specs;
+    #[allow(unused_imports)]
+    use specs::{Builder, DispatcherBuilder, World};
 
-	extern crate nalgebra;
-	#[allow(unused_imports)]
-	use nalgebra::Vector3;
+    extern crate nalgebra;
+    #[allow(unused_imports)]
+    use nalgebra::Vector3;
 
-	#[test]
-	fn test_euler() {
-		let mut pos = Position {
-			pos: Vector3::new(1., 1., 1.),
-		};
-		let mut vel = Velocity {
-			vel: Vector3::new(0., 1., 0.),
-		};
-		let time = 1.;
-		let mass = Mass {
-			value: 1. / constant::AMU,
-		};
-		let force = Force {
-			force: Vector3::new(1., 1., 1.),
-		};
-		euler_update(&mut vel, &mut pos, &force, &mass, time);
-		assert_eq!(vel.vel, Vector3::new(1., 2., 1.));
-		assert_eq!(pos.pos, Vector3::new(1., 2., 1.));
-	}
+    #[test]
+    fn test_euler() {
+        let mut pos = Position {
+            pos: Vector3::new(1., 1., 1.),
+        };
+        let mut vel = Velocity {
+            vel: Vector3::new(0., 1., 0.),
+        };
+        let time = 1.;
+        let mass = Mass {
+            value: 1. / constant::AMU,
+        };
+        let force = Force {
+            force: Vector3::new(1., 1., 1.),
+        };
+        euler_update(&mut vel, &mut pos, &force, &mass, time);
+        assert_eq!(vel.vel, Vector3::new(1., 2., 1.));
+        assert_eq!(pos.pos, Vector3::new(1., 2., 1.));
+    }
 
-	/// Tests the [EulerIntegrationSystem] by creating a mock world and integrating the trajectory of one entity.
-	#[test]
-	fn test_euler_integration() {
-		let mut world = World::new();
+    /// Tests the [EulerIntegrationSystem] by creating a mock world and integrating the trajectory of one entity.
+    #[test]
+    fn test_euler_integration() {
+        let mut world = World::new();
 
-		let mut dispatcher = DispatcherBuilder::new()
-			.with(EulerIntegrationSystem, "integrator", &[])
-			.build();
-		dispatcher.setup(&mut world);
+        let mut dispatcher = DispatcherBuilder::new()
+            .with(EulerIntegrationSystem, "integrator", &[])
+            .build();
+        dispatcher.setup(&mut world);
 
-		// create a particle with known force and mass
-		let force = Vector3::new(1.0, 0.0, 0.0);
-		let mass = 1.0;
-		let atom = world
-			.create_entity()
-			.with(Position {
-				pos: Vector3::new(0.0, 0.0, 0.0),
-			})
-			.with(Velocity {
-				vel: Vector3::new(0.0, 0.0, 0.0),
-			})
-			.with(Force { force: force })
-			.with(Mass {
-				value: mass / constant::AMU,
-			})
-			.build();
+        // create a particle with known force and mass
+        let force = Vector3::new(1.0, 0.0, 0.0);
+        let mass = 1.0;
+        let atom = world
+            .create_entity()
+            .with(Position {
+                pos: Vector3::new(0.0, 0.0, 0.0),
+            })
+            .with(Velocity {
+                vel: Vector3::new(0.0, 0.0, 0.0),
+            })
+            .with(Force { force: force })
+            .with(Mass {
+                value: mass / constant::AMU,
+            })
+            .build();
 
-		let dt = 1.0e-3;
-		world.insert(Timestep { delta: dt });
-		world.insert(Step { n: 0 });
+        let dt = 1.0e-3;
+        world.insert(Timestep { delta: dt });
+        world.insert(Step { n: 0 });
 
-		// run simulation loop 1_000 times.
-		let n_steps = 1_000;
-		for _i in 0..n_steps {
-			dispatcher.dispatch(&mut world);
-			world.maintain();
-		}
+        // run simulation loop 1_000 times.
+        let n_steps = 1_000;
+        for _i in 0..n_steps {
+            dispatcher.dispatch(&mut world);
+            world.maintain();
+        }
 
-		let a = force / mass;
-		let expected_v = a * (n_steps as f64 * dt);
+        let a = force / mass;
+        let expected_v = a * (n_steps as f64 * dt);
 
-		assert_approx_eq::assert_approx_eq!(
-			expected_v.norm(),
-			world
-				.read_storage::<Velocity>()
-				.get(atom)
-				.expect("atom not found.")
-				.vel
-				.norm(),
-			expected_v.norm() * 0.01
-		);
+        assert_approx_eq::assert_approx_eq!(
+            expected_v.norm(),
+            world
+                .read_storage::<Velocity>()
+                .get(atom)
+                .expect("atom not found.")
+                .vel
+                .norm(),
+            expected_v.norm() * 0.01
+        );
 
-		let expected_x = a * (n_steps as f64 * dt).powi(2) / 2.0;
-		assert_approx_eq::assert_approx_eq!(
-			expected_x.norm(),
-			world
-				.read_storage::<Position>()
-				.get(atom)
-				.expect("atom not found.")
-				.pos
-				.norm(),
-			expected_x.norm() * 0.01
-		);
-	}
+        let expected_x = a * (n_steps as f64 * dt).powi(2) / 2.0;
+        assert_approx_eq::assert_approx_eq!(
+            expected_x.norm(),
+            world
+                .read_storage::<Position>()
+                .get(atom)
+                .expect("atom not found.")
+                .pos
+                .norm(),
+            expected_x.norm() * 0.01
+        );
+    }
 
-	#[test]
-	fn test_add_old_force_system() {
-		let mut test_world = World::new();
+    #[test]
+    fn test_add_old_force_system() {
+        let mut test_world = World::new();
 
-		let mut dispatcher = DispatcherBuilder::new()
-			.with(AddOldForceToNewAtomsSystem, "", &[])
-			.build();
-		dispatcher.setup(&mut test_world);
-		test_world.register::<OldForce>();
+        let mut dispatcher = DispatcherBuilder::new()
+            .with(AddOldForceToNewAtomsSystem, "", &[])
+            .build();
+        dispatcher.setup(&mut test_world);
+        test_world.register::<OldForce>();
 
-		let test_entity = test_world.create_entity().with(NewlyCreated {}).build();
+        let test_entity = test_world.create_entity().with(NewlyCreated {}).build();
 
-		dispatcher.dispatch(&mut test_world);
-		test_world.maintain();
+        dispatcher.dispatch(&mut test_world);
+        test_world.maintain();
 
-		let old_forces = test_world.read_storage::<OldForce>();
-		assert_eq!(
-			old_forces.contains(test_entity),
-			true,
-			"OldForce component not added to test entity."
-		);
-	}
+        let old_forces = test_world.read_storage::<OldForce>();
+        assert_eq!(
+            old_forces.contains(test_entity),
+            true,
+            "OldForce component not added to test entity."
+        );
+    }
 
-	#[test]
-	fn test_velocity_verlet_integration() {
-		let mut world = World::new();
+    #[test]
+    fn test_velocity_verlet_integration() {
+        let mut world = World::new();
 
-		let mut dispatcher = DispatcherBuilder::new()
-			.with(
-				VelocityVerletIntegratePositionSystem,
-				"integrate_position",
-				&[],
-			)
-			.with(
-				VelocityVerletIntegrateVelocitySystem,
-				"integrate_velocity",
-				&["integrate_position"],
-			)
-			.build();
-		dispatcher.setup(&mut world);
+        let mut dispatcher = DispatcherBuilder::new()
+            .with(
+                VelocityVerletIntegratePositionSystem,
+                "integrate_position",
+                &[],
+            )
+            .with(
+                VelocityVerletIntegrateVelocitySystem,
+                "integrate_velocity",
+                &["integrate_position"],
+            )
+            .build();
+        dispatcher.setup(&mut world);
 
-		// create a particle with known force and mass
-		let force = Vector3::new(1.0, 0.0, 0.0);
-		let mass = 1.0;
-		let atom = world
-			.create_entity()
-			.with(Position {
-				pos: Vector3::new(0.0, 0.0, 0.0),
-			})
-			.with(Velocity {
-				vel: Vector3::new(0.0, 0.0, 0.0),
-			})
-			.with(Force { force: force })
-			.with(OldForce {
-				0: Force { force: force },
-			})
-			.with(Mass {
-				value: mass / constant::AMU,
-			})
-			.build();
+        // create a particle with known force and mass
+        let force = Vector3::new(1.0, 0.0, 0.0);
+        let mass = 1.0;
+        let atom = world
+            .create_entity()
+            .with(Position {
+                pos: Vector3::new(0.0, 0.0, 0.0),
+            })
+            .with(Velocity {
+                vel: Vector3::new(0.0, 0.0, 0.0),
+            })
+            .with(Force { force: force })
+            .with(OldForce {
+                0: Force { force: force },
+            })
+            .with(Mass {
+                value: mass / constant::AMU,
+            })
+            .build();
 
-		let dt = 1.0e-3;
-		world.insert(Timestep { delta: dt });
-		world.insert(Step { n: 0 });
+        let dt = 1.0e-3;
+        world.insert(Timestep { delta: dt });
+        world.insert(Step { n: 0 });
 
-		// run simulation loop 1_000 times.
-		let n_steps = 1_000;
-		for _i in 0..n_steps {
-			dispatcher.dispatch(&mut world);
-			world.maintain();
-		}
+        // run simulation loop 1_000 times.
+        let n_steps = 1_000;
+        for _i in 0..n_steps {
+            dispatcher.dispatch(&mut world);
+            world.maintain();
+        }
 
-		let a = force / mass;
-		let expected_v = a * (n_steps as f64 * dt);
+        let a = force / mass;
+        let expected_v = a * (n_steps as f64 * dt);
 
-		assert_approx_eq::assert_approx_eq!(
-			expected_v.norm(),
-			world
-				.read_storage::<Velocity>()
-				.get(atom)
-				.expect("atom not found.")
-				.vel
-				.norm(),
-			expected_v.norm() * 0.01
-		);
+        assert_approx_eq::assert_approx_eq!(
+            expected_v.norm(),
+            world
+                .read_storage::<Velocity>()
+                .get(atom)
+                .expect("atom not found.")
+                .vel
+                .norm(),
+            expected_v.norm() * 0.01
+        );
 
-		let expected_x = a * (n_steps as f64 * dt).powi(2) / 2.0;
-		assert_approx_eq::assert_approx_eq!(
-			expected_x.norm(),
-			world
-				.read_storage::<Position>()
-				.get(atom)
-				.expect("atom not found.")
-				.pos
-				.norm(),
-			expected_x.norm() * 0.01
-		);
-	}
+        let expected_x = a * (n_steps as f64 * dt).powi(2) / 2.0;
+        assert_approx_eq::assert_approx_eq!(
+            expected_x.norm(),
+            world
+                .read_storage::<Position>()
+                .get(atom)
+                .expect("atom not found.")
+                .pos
+                .norm(),
+            expected_x.norm() * 0.01
+        );
+    }
 }

--- a/src/magnetic/mod.rs
+++ b/src/magnetic/mod.rs
@@ -8,8 +8,8 @@ use crate::initiate::NewlyCreated;
 use crate::integrator::INTEGRATE_POSITION_SYSTEM_NAME;
 use nalgebra::{Matrix3, Vector3};
 use specs::{
-	Component, DispatcherBuilder, Entities, Join, LazyUpdate, Read, ReadStorage, System,
-	VecStorage, World, WriteStorage,
+    Component, DispatcherBuilder, Entities, Join, LazyUpdate, Read, ReadStorage, System,
+    VecStorage, World, WriteStorage,
 };
 
 pub mod force;
@@ -23,67 +23,67 @@ use std::fmt;
 /// A component that stores the magnetic field at an entity's location.
 #[derive(Copy, Clone)]
 pub struct MagneticFieldSampler {
-	/// Vector representing the magnetic field components along x,y,z in units of Tesla.
-	pub field: Vector3<f64>,
+    /// Vector representing the magnetic field components along x,y,z in units of Tesla.
+    pub field: Vector3<f64>,
 
-	/// Magnitude of the magnetic field in units of Tesla
-	pub magnitude: f64,
+    /// Magnitude of the magnetic field in units of Tesla
+    pub magnitude: f64,
 
-	/// Local gradient of the magnitude of the magnetic field in T/m
-	pub gradient: Vector3<f64>,
+    /// Local gradient of the magnitude of the magnetic field in T/m
+    pub gradient: Vector3<f64>,
 
-	///Local jacobian of magnetic field
-	pub jacobian: Matrix3<f64>,
+    ///Local jacobian of magnetic field
+    pub jacobian: Matrix3<f64>,
 }
 impl MagneticFieldSampler {
-	pub fn tesla(b_field: Vector3<f64>) -> Self {
-		MagneticFieldSampler {
-			field: b_field,
-			magnitude: b_field.norm(),
-			gradient: Vector3::new(0.0, 0.0, 0.0),
-			jacobian: Matrix3::zeros(),
-		}
-	}
+    pub fn tesla(b_field: Vector3<f64>) -> Self {
+        MagneticFieldSampler {
+            field: b_field,
+            magnitude: b_field.norm(),
+            gradient: Vector3::new(0.0, 0.0, 0.0),
+            jacobian: Matrix3::zeros(),
+        }
+    }
 }
 impl Component for MagneticFieldSampler {
-	type Storage = VecStorage<Self>;
+    type Storage = VecStorage<Self>;
 }
 impl fmt::Display for MagneticFieldSampler {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		write!(
-			f,
-			"({:?},{:?},{:?})",
-			self.field[0], self.field[1], self.field[2]
-		)
-	}
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "({:?},{:?},{:?})",
+            self.field[0], self.field[1], self.field[2]
+        )
+    }
 }
 
 impl Default for MagneticFieldSampler {
-	fn default() -> Self {
-		MagneticFieldSampler {
-			field: Vector3::new(0.0, 0.0, 0.0),
-			magnitude: 0.0,
-			gradient: Vector3::new(0.0, 0.0, 0.0),
-			jacobian: Matrix3::zeros(),
-		}
-	}
+    fn default() -> Self {
+        MagneticFieldSampler {
+            field: Vector3::new(0.0, 0.0, 0.0),
+            magnitude: 0.0,
+            gradient: Vector3::new(0.0, 0.0, 0.0),
+            jacobian: Matrix3::zeros(),
+        }
+    }
 }
 
 /// System that clears the magnetic field samplers each frame.
 pub struct ClearMagneticFieldSamplerSystem;
 
 impl<'a> System<'a> for ClearMagneticFieldSamplerSystem {
-	type SystemData = WriteStorage<'a, MagneticFieldSampler>;
-	fn run(&mut self, mut sampler: Self::SystemData) {
-		use rayon::prelude::*;
+    type SystemData = WriteStorage<'a, MagneticFieldSampler>;
+    fn run(&mut self, mut sampler: Self::SystemData) {
+        use rayon::prelude::*;
 
-		(&mut sampler).par_join().for_each(|mut sampler| {
-			sampler.magnitude = 0.;
-			sampler.field = Vector3::new(0.0, 0.0, 0.0);
-			sampler.gradient = Vector3::new(0.0, 0.0, 0.0);
-			sampler.jacobian = Matrix3::zeros();
-		});
-	}
+        (&mut sampler).par_join().for_each(|mut sampler| {
+            sampler.magnitude = 0.;
+            sampler.field = Vector3::new(0.0, 0.0, 0.0);
+            sampler.gradient = Vector3::new(0.0, 0.0, 0.0);
+            sampler.jacobian = Matrix3::zeros();
+        });
+    }
 }
 
 /// System that calculates the magnitude of the magnetic field.
@@ -93,17 +93,17 @@ impl<'a> System<'a> for ClearMagneticFieldSamplerSystem {
 pub struct CalculateMagneticFieldMagnitudeSystem;
 
 impl<'a> System<'a> for CalculateMagneticFieldMagnitudeSystem {
-	type SystemData = WriteStorage<'a, MagneticFieldSampler>;
-	fn run(&mut self, mut sampler: Self::SystemData) {
-		use rayon::prelude::*;
+    type SystemData = WriteStorage<'a, MagneticFieldSampler>;
+    fn run(&mut self, mut sampler: Self::SystemData) {
+        use rayon::prelude::*;
 
-		(&mut sampler).par_join().for_each(|mut sampler| {
-			sampler.magnitude = sampler.field.norm();
-			if sampler.magnitude.is_nan() {
-				sampler.magnitude = 0.0;
-			}
-		});
-	}
+        (&mut sampler).par_join().for_each(|mut sampler| {
+            sampler.magnitude = sampler.field.norm();
+            if sampler.magnitude.is_nan() {
+                sampler.magnitude = 0.0;
+            }
+        });
+    }
 }
 
 /// System that calculates the gradient of the magnitude of the magnetic field.
@@ -112,19 +112,19 @@ impl<'a> System<'a> for CalculateMagneticFieldMagnitudeSystem {
 pub struct CalculateMagneticMagnitudeGradientSystem;
 
 impl<'a> System<'a> for CalculateMagneticMagnitudeGradientSystem {
-	type SystemData = WriteStorage<'a, MagneticFieldSampler>;
-	fn run(&mut self, mut sampler: Self::SystemData) {
-		use rayon::prelude::*;
+    type SystemData = WriteStorage<'a, MagneticFieldSampler>;
+    fn run(&mut self, mut sampler: Self::SystemData) {
+        use rayon::prelude::*;
 
-		(&mut sampler).par_join().for_each(|mut sampler| {
-			let mut gradient = Vector3::new(0.0, 0.0, 0.0);
-			for i in 0..3 {
-				gradient[i] =
-					(1.0 / (sampler.magnitude)) * (sampler.field.dot(&sampler.jacobian.column(i)));
-			}
-			sampler.gradient = gradient;
-		});
-	}
+        (&mut sampler).par_join().for_each(|mut sampler| {
+            let mut gradient = Vector3::new(0.0, 0.0, 0.0);
+            for i in 0..3 {
+                gradient[i] =
+                    (1.0 / (sampler.magnitude)) * (sampler.field.dot(&sampler.jacobian.column(i)));
+            }
+            sampler.gradient = gradient;
+        });
+    }
 }
 
 /// Attachs the MagneticFieldSampler component to newly created atoms.
@@ -132,16 +132,16 @@ impl<'a> System<'a> for CalculateMagneticMagnitudeGradientSystem {
 pub struct AttachFieldSamplersToNewlyCreatedAtomsSystem;
 
 impl<'a> System<'a> for AttachFieldSamplersToNewlyCreatedAtomsSystem {
-	type SystemData = (
-		Entities<'a>,
-		ReadStorage<'a, NewlyCreated>,
-		Read<'a, LazyUpdate>,
-	);
-	fn run(&mut self, (ent, newly_created, updater): Self::SystemData) {
-		for (ent, _nc) in (&ent, &newly_created).join() {
-			updater.insert(ent, MagneticFieldSampler::default());
-		}
-	}
+    type SystemData = (
+        Entities<'a>,
+        ReadStorage<'a, NewlyCreated>,
+        Read<'a, LazyUpdate>,
+    );
+    fn run(&mut self, (ent, newly_created, updater): Self::SystemData) {
+        for (ent, _nc) in (&ent, &newly_created).join() {
+            updater.insert(ent, MagneticFieldSampler::default());
+        }
+    }
 }
 
 /// Adds the systems required by magnetics to the dispatcher.
@@ -152,211 +152,210 @@ impl<'a> System<'a> for AttachFieldSamplersToNewlyCreatedAtomsSystem {
 ///
 /// `deps`: any dependencies that must be completed before the magnetics systems run.
 pub fn add_systems_to_dispatch(builder: &mut DispatcherBuilder<'static, 'static>, deps: &[&str]) {
-	builder.add(ClearMagneticFieldSamplerSystem, "magnetics_clear", deps);
-	builder.add(
-		quadrupole::Sample3DQuadrupoleFieldSystem,
-		"magnetics_quadrupole",
-		&[
-			"magnetics_clear",
-			crate::integrator::INTEGRATE_POSITION_SYSTEM_NAME,
-		],
-	);
-	builder.add(
-		quadrupole::Sample2DQuadrupoleFieldSystem,
-		"magnetics_2dquadrupole",
-		&["magnetics_quadrupole"],
-	);
-	builder.add(
-		uniform::UniformMagneticFieldSystem,
-		"magnetics_uniform",
-		&["magnetics_2dquadrupole"],
-	);
-	builder.add(
-		top::TimeOrbitingPotentialSystem,
-		"magnetics_top",
-		&["magnetics_uniform"],
-	);
-	builder.add(
-		grid::SampleMagneticGridSystem,
-		"magnetics_grid",
-		&["magnetics_top", INTEGRATE_POSITION_SYSTEM_NAME],
-	);
-	builder.add(
-		CalculateMagneticFieldMagnitudeSystem,
-		"magnetics_magnitude",
-		&["magnetics_grid"],
-	);
-	builder.add(
-		CalculateMagneticMagnitudeGradientSystem,
-		"magnetics_gradient",
-		&["magnetics_magnitude"],
-	);
-	builder.add(
-		AttachFieldSamplersToNewlyCreatedAtomsSystem,
-		"add_magnetic_field_samplers",
-		&[],
-	);
-	builder.add(
-		zeeman::AttachZeemanShiftSamplersToNewlyCreatedAtomsSystem,
-		"attach_zeeman_shift_samplers",
-		&[],
-	);
-	builder.add(
-		zeeman::CalculateZeemanShiftSystem,
-		"zeeman_shift",
-		&["magnetics_magnitude"],
-	);
+    builder.add(ClearMagneticFieldSamplerSystem, "magnetics_clear", deps);
+    builder.add(
+        quadrupole::Sample3DQuadrupoleFieldSystem,
+        "magnetics_quadrupole",
+        &[
+            "magnetics_clear",
+            crate::integrator::INTEGRATE_POSITION_SYSTEM_NAME,
+        ],
+    );
+    builder.add(
+        quadrupole::Sample2DQuadrupoleFieldSystem,
+        "magnetics_2dquadrupole",
+        &["magnetics_quadrupole"],
+    );
+    builder.add(
+        uniform::UniformMagneticFieldSystem,
+        "magnetics_uniform",
+        &["magnetics_2dquadrupole"],
+    );
+    builder.add(
+        top::TimeOrbitingPotentialSystem,
+        "magnetics_top",
+        &["magnetics_uniform"],
+    );
+    builder.add(
+        grid::SampleMagneticGridSystem,
+        "magnetics_grid",
+        &["magnetics_top", INTEGRATE_POSITION_SYSTEM_NAME],
+    );
+    builder.add(
+        CalculateMagneticFieldMagnitudeSystem,
+        "magnetics_magnitude",
+        &["magnetics_grid"],
+    );
+    builder.add(
+        CalculateMagneticMagnitudeGradientSystem,
+        "magnetics_gradient",
+        &["magnetics_magnitude"],
+    );
+    builder.add(
+        AttachFieldSamplersToNewlyCreatedAtomsSystem,
+        "add_magnetic_field_samplers",
+        &[],
+    );
+    builder.add(
+        zeeman::AttachZeemanShiftSamplersToNewlyCreatedAtomsSystem,
+        "attach_zeeman_shift_samplers",
+        &[],
+    );
+    builder.add(
+        zeeman::CalculateZeemanShiftSystem,
+        "zeeman_shift",
+        &["magnetics_magnitude"],
+    );
 }
 
 /// Registers resources required by magnetics to the ecs world.
 pub fn register_components(world: &mut World) {
-	world.register::<uniform::UniformMagneticField>();
-	world.register::<quadrupole::QuadrupoleField3D>();
-	world.register::<quadrupole::QuadrupoleField2D>();
-	world.register::<MagneticFieldSampler>();
-	world.register::<grid::PrecalculatedMagneticFieldGrid>();
+    world.register::<uniform::UniformMagneticField>();
+    world.register::<quadrupole::QuadrupoleField3D>();
+    world.register::<quadrupole::QuadrupoleField2D>();
+    world.register::<MagneticFieldSampler>();
+    world.register::<grid::PrecalculatedMagneticFieldGrid>();
 }
 
 #[cfg(test)]
 pub mod tests {
-	use super::*;
-	use crate::atom::Position;
-	use crate::magnetic::quadrupole::{QuadrupoleField3D, Sample3DQuadrupoleFieldSystem};
-	use assert_approx_eq::assert_approx_eq;
-	use specs::prelude::*;
+    use super::*;
+    use crate::atom::Position;
+    use crate::magnetic::quadrupole::{QuadrupoleField3D, Sample3DQuadrupoleFieldSystem};
+    use assert_approx_eq::assert_approx_eq;
 
-	/// Tests the correct implementation of the magnetics systems and dispatcher.
-	/// This is done by setting up a test world and ensuring that the magnetic systems perform the correct operations on test entities.
-	#[test]
-	fn test_magnetics_systems() {
-		let mut test_world = World::new();
-		register_components(&mut test_world);
-		test_world.register::<NewlyCreated>();
-		test_world.register::<zeeman::ZeemanShiftSampler>();
-		let mut builder = DispatcherBuilder::new();
-		builder.add(
-			crate::integrator::VelocityVerletIntegratePositionSystem {},
-			crate::integrator::INTEGRATE_POSITION_SYSTEM_NAME,
-			&[],
-		);
-		add_systems_to_dispatch(&mut builder, &[]);
-		let mut dispatcher = builder.build();
-		dispatcher.setup(&mut test_world);
-		test_world.insert(crate::integrator::Step { n: 0 });
-		test_world.insert(crate::integrator::Timestep { delta: 1.0e-6 });
+    /// Tests the correct implementation of the magnetics systems and dispatcher.
+    /// This is done by setting up a test world and ensuring that the magnetic systems perform the correct operations on test entities.
+    #[test]
+    fn test_magnetics_systems() {
+        let mut test_world = World::new();
+        register_components(&mut test_world);
+        test_world.register::<NewlyCreated>();
+        test_world.register::<zeeman::ZeemanShiftSampler>();
+        let mut builder = DispatcherBuilder::new();
+        builder.add(
+            crate::integrator::VelocityVerletIntegratePositionSystem {},
+            crate::integrator::INTEGRATE_POSITION_SYSTEM_NAME,
+            &[],
+        );
+        add_systems_to_dispatch(&mut builder, &[]);
+        let mut dispatcher = builder.build();
+        dispatcher.setup(&mut test_world);
+        test_world.insert(crate::integrator::Step { n: 0 });
+        test_world.insert(crate::integrator::Timestep { delta: 1.0e-6 });
 
-		test_world
-			.create_entity()
-			.with(uniform::UniformMagneticField {
-				field: Vector3::new(2.0, 0.0, 0.0),
-			})
-			.with(quadrupole::QuadrupoleField3D::gauss_per_cm(
-				100.0,
-				Vector3::z(),
-			))
-			.with(Position {
-				pos: Vector3::new(0.0, 0.0, 0.0),
-			})
-			.build();
+        test_world
+            .create_entity()
+            .with(uniform::UniformMagneticField {
+                field: Vector3::new(2.0, 0.0, 0.0),
+            })
+            .with(quadrupole::QuadrupoleField3D::gauss_per_cm(
+                100.0,
+                Vector3::z(),
+            ))
+            .with(Position {
+                pos: Vector3::new(0.0, 0.0, 0.0),
+            })
+            .build();
 
-		let sampler_entity = test_world
-			.create_entity()
-			.with(Position {
-				pos: Vector3::new(1.0, 1.0, 1.0),
-			})
-			.with(MagneticFieldSampler::default())
-			.build();
+        let sampler_entity = test_world
+            .create_entity()
+            .with(Position {
+                pos: Vector3::new(1.0, 1.0, 1.0),
+            })
+            .with(MagneticFieldSampler::default())
+            .build();
 
-		dispatcher.dispatch(&mut test_world);
+        dispatcher.dispatch(&mut test_world);
 
-		let samplers = test_world.read_storage::<MagneticFieldSampler>();
-		let sampler = samplers.get(sampler_entity);
-		assert_eq!(
-			sampler.expect("entity not found").field,
-			Vector3::new(2.0 + 1.0, 1.0, -2.0)
-		);
-	}
+        let samplers = test_world.read_storage::<MagneticFieldSampler>();
+        let sampler = samplers.get(sampler_entity);
+        assert_eq!(
+            sampler.expect("entity not found").field,
+            Vector3::new(2.0 + 1.0, 1.0, -2.0)
+        );
+    }
 
-	/// Tests that magnetic field samplers are added to newly created atoms.
-	#[test]
-	fn test_field_samplers_are_added() {
-		let mut test_world = World::new();
-		register_components(&mut test_world);
-		test_world.register::<NewlyCreated>();
-		test_world.register::<zeeman::ZeemanShiftSampler>();
-		let mut builder = DispatcherBuilder::new();
-		builder.add(
-			crate::integrator::VelocityVerletIntegratePositionSystem {},
-			crate::integrator::INTEGRATE_POSITION_SYSTEM_NAME,
-			&[],
-		);
-		add_systems_to_dispatch(&mut builder, &[]);
-		let mut dispatcher = builder.build();
-		dispatcher.setup(&mut test_world);
-		test_world.insert(crate::integrator::Step { n: 0 });
-		test_world.insert(crate::integrator::Timestep { delta: 1.0e-6 });
+    /// Tests that magnetic field samplers are added to newly created atoms.
+    #[test]
+    fn test_field_samplers_are_added() {
+        let mut test_world = World::new();
+        register_components(&mut test_world);
+        test_world.register::<NewlyCreated>();
+        test_world.register::<zeeman::ZeemanShiftSampler>();
+        let mut builder = DispatcherBuilder::new();
+        builder.add(
+            crate::integrator::VelocityVerletIntegratePositionSystem {},
+            crate::integrator::INTEGRATE_POSITION_SYSTEM_NAME,
+            &[],
+        );
+        add_systems_to_dispatch(&mut builder, &[]);
+        let mut dispatcher = builder.build();
+        dispatcher.setup(&mut test_world);
+        test_world.insert(crate::integrator::Step { n: 0 });
+        test_world.insert(crate::integrator::Timestep { delta: 1.0e-6 });
 
-		let sampler_entity = test_world.create_entity().with(NewlyCreated).build();
+        let sampler_entity = test_world.create_entity().with(NewlyCreated).build();
 
-		dispatcher.dispatch(&mut test_world);
-		test_world.maintain();
+        dispatcher.dispatch(&mut test_world);
+        test_world.maintain();
 
-		let samplers = test_world.read_storage::<MagneticFieldSampler>();
-		assert_eq!(samplers.contains(sampler_entity), true);
-	}
+        let samplers = test_world.read_storage::<MagneticFieldSampler>();
+        assert_eq!(samplers.contains(sampler_entity), true);
+    }
 
-	// Test correct calculation of magnetic field gradient
-	#[test]
+    // Test correct calculation of magnetic field gradient
+    #[test]
 
-	fn test_magnetic_gradient_system() {
-		let mut test_world = World::new();
+    fn test_magnetic_gradient_system() {
+        let mut test_world = World::new();
 
-		test_world.register::<QuadrupoleField3D>();
-		test_world.register::<Position>();
-		test_world.register::<MagneticFieldSampler>();
+        test_world.register::<QuadrupoleField3D>();
+        test_world.register::<Position>();
+        test_world.register::<MagneticFieldSampler>();
 
-		let atom1 = test_world
-			.create_entity()
-			.with(Position {
-				pos: Vector3::new(2.0, 1.0, -5.0),
-			})
-			.with(MagneticFieldSampler::default())
-			.build();
+        let atom1 = test_world
+            .create_entity()
+            .with(Position {
+                pos: Vector3::new(2.0, 1.0, -5.0),
+            })
+            .with(MagneticFieldSampler::default())
+            .build();
 
-		test_world
-			.create_entity()
-			.with(QuadrupoleField3D::gauss_per_cm(2.0, Vector3::z()))
-			.with(Position {
-				pos: Vector3::new(0.0, 0.0, 0.0),
-			})
-			.build();
+        test_world
+            .create_entity()
+            .with(QuadrupoleField3D::gauss_per_cm(2.0, Vector3::z()))
+            .with(Position {
+                pos: Vector3::new(0.0, 0.0, 0.0),
+            })
+            .build();
 
-		test_world
-			.create_entity()
-			.with(QuadrupoleField3D::gauss_per_cm(1.0, Vector3::z()))
-			.with(Position {
-				pos: Vector3::new(0.0, 0.0, 0.0),
-			})
-			.build();
+        test_world
+            .create_entity()
+            .with(QuadrupoleField3D::gauss_per_cm(1.0, Vector3::z()))
+            .with(Position {
+                pos: Vector3::new(0.0, 0.0, 0.0),
+            })
+            .build();
 
-		let mut quad_system = Sample3DQuadrupoleFieldSystem;
-		quad_system.run_now(&test_world);
+        let mut quad_system = Sample3DQuadrupoleFieldSystem;
+        quad_system.run_now(&test_world);
 
-		let mut magnitude_system = CalculateMagneticFieldMagnitudeSystem;
-		magnitude_system.run_now(&test_world);
-		let mut gradient_system = CalculateMagneticMagnitudeGradientSystem;
-		gradient_system.run_now(&test_world);
+        let mut magnitude_system = CalculateMagneticFieldMagnitudeSystem;
+        magnitude_system.run_now(&test_world);
+        let mut gradient_system = CalculateMagneticMagnitudeGradientSystem;
+        gradient_system.run_now(&test_world);
 
-		test_world.maintain();
-		let sampler_storage = test_world.read_storage::<MagneticFieldSampler>();
+        test_world.maintain();
+        let sampler_storage = test_world.read_storage::<MagneticFieldSampler>();
 
-		let test_gradient = sampler_storage
-			.get(atom1)
-			.expect("entity not found")
-			.gradient;
+        let test_gradient = sampler_storage
+            .get(atom1)
+            .expect("entity not found")
+            .gradient;
 
-		assert_approx_eq!(test_gradient[0], 5.8554e-3, 1e-6_f64);
-		assert_approx_eq!(test_gradient[1], 2.9277e-3, 1e-6_f64);
-		assert_approx_eq!(test_gradient[2], -0.058554, 1e-6_f64);
-	}
+        assert_approx_eq!(test_gradient[0], 5.8554e-3, 1e-6_f64);
+        assert_approx_eq!(test_gradient[1], 2.9277e-3, 1e-6_f64);
+        assert_approx_eq!(test_gradient[2], -0.058554, 1e-6_f64);
+    }
 }

--- a/src/maths.rs
+++ b/src/maths.rs
@@ -15,17 +15,17 @@ use nalgebra::Vector3;
 ///
 /// `dir`: vector pointing along the line.
 pub fn get_relative_coordinates_line_point(
-	pos: &Vector3<f64>,
-	line_point: &Vector3<f64>,
-	dir: &Vector3<f64>,
-	frame: &crate::laser::frame::Frame,
+    pos: &Vector3<f64>,
+    line_point: &Vector3<f64>,
+    dir: &Vector3<f64>,
+    frame: &crate::laser::frame::Frame,
 ) -> (f64, f64, f64) {
-	let rela_cood = pos - line_point;
-	let z = rela_cood.dot(&dir) / dir.norm();
-	let r_vec = rela_cood - z * dir;
-	let x = r_vec.dot(&frame.x_vector);
-	let y = r_vec.dot(&frame.y_vector);
-	(x, y, z)
+    let rela_cood = pos - line_point;
+    let z = rela_cood.dot(&dir) / dir.norm();
+    let r_vec = rela_cood - z * dir;
+    let x = r_vec.dot(&frame.x_vector);
+    let y = r_vec.dot(&frame.y_vector);
+    (x, y, z)
 }
 
 /// Get miniminum distance between a point and a line.
@@ -38,33 +38,33 @@ pub fn get_relative_coordinates_line_point(
 ///
 /// `dir`: vector pointing along the line.
 pub fn get_minimum_distance_line_point(
-	pos: &Vector3<f64>,
-	line_point: &Vector3<f64>,
-	dir: &Vector3<f64>,
+    pos: &Vector3<f64>,
+    line_point: &Vector3<f64>,
+    dir: &Vector3<f64>,
 ) -> (f64, f64) {
-	let rela_cood = pos - line_point;
-	let distance = (dir.cross(&rela_cood) / dir.norm()).norm();
-	let z = rela_cood.dot(&dir) / dir.norm();
-	(distance, z)
+    let rela_cood = pos - line_point;
+    let distance = (dir.cross(&rela_cood) / dir.norm()).norm();
+    let z = rela_cood.dot(&dir) / dir.norm();
+    (distance, z)
 }
 
 /// A normalised gaussian distribution.
 ///
 /// The distribution is normalised such that the 2D area underneath a gaussian dist with sigma_x=sigma_y=std is equal to 1.
 pub fn gaussian_dis(std: f64, distance_squared: f64) -> f64 {
-	1.0 / (2.0 * PI * std * std) * EXP.powf(-distance_squared / 2.0 / (std * std))
+    1.0 / (2.0 * PI * std * std) * EXP.powf(-distance_squared / 2.0 / (std * std))
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	#[test]
-	fn test_minimum_distance_line_point() {
-		let pos = Vector3::new(1., 1., 1.);
-		let centre = Vector3::new(0., 1., 1.);
-		let dir = Vector3::new(1., 2., 2.);
-		let (distance, _) = get_minimum_distance_line_point(&pos, &centre, &dir);
-		assert!(distance > 0.942, distance < 0.943);
-	}
+    #[test]
+    fn test_minimum_distance_line_point() {
+        let pos = Vector3::new(1., 1., 1.);
+        let centre = Vector3::new(0., 1., 1.);
+        let dir = Vector3::new(1., 2., 2.);
+        let (distance, _) = get_minimum_distance_line_point(&pos, &centre, &dir);
+        assert!(distance > 0.942, "{}", distance < 0.943);
+    }
 }


### PR DESCRIPTION
This PR mainly applied the following changes

1. updated dependencies to the latest versions
  - `specs` to version 0.17.0
  - `nalgebra` to version 0.29.0
  - `hashbrown` to version 0.11.2
  - `gnuplot` to 0.0.37
2. fixed warning messages caused by
  - removing unnecessary borrowing
  - migrating `assert!()` macro format that will be deprecated in edition 2021 to comply to edition 2021's standard

The above changes have passed all the tests.