### PR TITLE
Adding badges for crate version and docs linking to crates.io and docs.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,10 @@
 # AtomECS
 > Simulate cold atoms with rust.
- 
-<div align="left">
-<!-- Crates version -->
-<a href="https://crates.io/crates/atomecs">
-<img src="https://img.shields.io/crates/v/atomecs.svg?style=flat"
-alt="Crates.io version" />
-</a>
-<!-- docs.rs docs -->
-<a href="https://docs.rs/atomecs">
-<img src="https://img.shields.io/badge/docs-latest-blue.svg?style=flat"
-alt="docs.rs docs" />
-</a>
-</div>
 
 **New:** Paper out now on [arxiv](https://arxiv.org/abs/2105.06447)
 
+[![crate_version](https://img.shields.io/crates/v/atomecs.svg?style=flat)(https://crates.io/crates/atomecs)]
+[![crate_version](https://img.shields.io/badge/docs-latest-blue.svg?style=flat)(https://docs.rs/atomecs)]
 [![build](https://github.com/TeamAtomECS/AtomECS/actions/workflows/build.yml/badge.svg)](https://github.com/TeamAtomECS/AtomECS/actions/workflows/build.yml) [![unit_tests](https://github.com/TeamAtomECS/AtomECS/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/TeamAtomECS/AtomECS/actions/workflows/unit-tests.yml)
 
 `atomecs` is a rust crate for simulating ultracold atom experiments. It supports numerous features:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AtomECS
 > Simulate cold atoms with rust.
  
-<div align="center">
+<div align="left">
 <!-- Crates version -->
 <a href="https://crates.io/crates/atomecs">
 <img src="https://img.shields.io/crates/v/atomecs.svg?style=flat"

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 
 **New:** Paper out now on [arxiv](https://arxiv.org/abs/2105.06447)
 
-[![crate_version](https://img.shields.io/crates/v/atomecs.svg?style=flat)(https://crates.io/crates/atomecs)]
-[![crate_version](https://img.shields.io/badge/docs-latest-blue.svg?style=flat)(https://docs.rs/atomecs)]
+[![crate_version](https://img.shields.io/crates/v/atomecs.svg?style=flat)](https://crates.io/crates/atomecs)
+[![crate_version](https://img.shields.io/badge/docs-latest-blue.svg?style=flat)](https://docs.rs/atomecs)
 [![build](https://github.com/TeamAtomECS/AtomECS/actions/workflows/build.yml/badge.svg)](https://github.com/TeamAtomECS/AtomECS/actions/workflows/build.yml) [![unit_tests](https://github.com/TeamAtomECS/AtomECS/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/TeamAtomECS/AtomECS/actions/workflows/unit-tests.yml)
 
 `atomecs` is a rust crate for simulating ultracold atom experiments. It supports numerous features:

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # AtomECS
 > Simulate cold atoms with rust.
  
-//! <div align="center">
-//! <!-- Crates version -->
-//! <a href="https://crates.io/crates/atomecs">
-//! <img src="https://img.shields.io/crates/v/atomecs.svg?style=flat"
-//! alt="Crates.io version" />
-//! </a>
-//! <!-- docs.rs docs -->
-//! <a href="https://docs.rs/atomecs">
-//! <img src="https://img.shields.io/badge/docs-latest-blue.svg?style=flat"
-//! alt="docs.rs docs" />
-//! </a>
-//! </div>
+<div align="center">
+<!-- Crates version -->
+<a href="https://crates.io/crates/atomecs">
+<img src="https://img.shields.io/crates/v/atomecs.svg?style=flat"
+alt="Crates.io version" />
+</a>
+<!-- docs.rs docs -->
+<a href="https://docs.rs/atomecs">
+<img src="https://img.shields.io/badge/docs-latest-blue.svg?style=flat"
+alt="docs.rs docs" />
+</a>
+</div>
 
 **New:** Paper out now on [arxiv](https://arxiv.org/abs/2105.06447)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # AtomECS
 > Simulate cold atoms with rust.
  
+//! <div align="center">
+//! <!-- Crates version -->
+//! <a href="https://crates.io/crates/atomecs">
+//! <img src="https://img.shields.io/crates/v/atomecs.svg?style=flat"
+//! alt="Crates.io version" />
+//! </a>
+//! <!-- docs.rs docs -->
+//! <a href="https://docs.rs/atomecs">
+//! <img src="https://img.shields.io/badge/docs-latest-blue.svg?style=flat"
+//! alt="docs.rs docs" />
+//! </a>
+//! </div>
+
 **New:** Paper out now on [arxiv](https://arxiv.org/abs/2105.06447)
 
 [![build](https://github.com/TeamAtomECS/AtomECS/actions/workflows/build.yml/badge.svg)](https://github.com/TeamAtomECS/AtomECS/actions/workflows/build.yml) [![unit_tests](https://github.com/TeamAtomECS/AtomECS/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/TeamAtomECS/AtomECS/actions/workflows/unit-tests.yml)


### PR DESCRIPTION
Two badges are added linking to the crates.io page and docs.rs page for this crate.

![Screenshot 2021-12-07 at 10-56-56 minghuaw AtomECS Cold atom simulation code](https://user-images.githubusercontent.com/29760666/145089495-bc2f77a2-e928-4ac3-8cb2-742d35fea0fa.png)
