### PR TITLE
Made fields in the Quadrupole* structs public

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,10 @@
 # AtomECS
 > Simulate cold atoms with rust.
- 
-<div align="left">
-<!-- Crates version -->
-<a href="https://crates.io/crates/atomecs">
-<img src="https://img.shields.io/crates/v/atomecs.svg?style=flat"
-alt="Crates.io version" />
-</a>
-<!-- docs.rs docs -->
-<a href="https://docs.rs/atomecs">
-<img src="https://img.shields.io/badge/docs-latest-blue.svg?style=flat"
-alt="docs.rs docs" />
-</a>
-</div>
 
 **New:** Paper out now on [arxiv](https://arxiv.org/abs/2105.06447)
 
+[![crate_version](https://img.shields.io/crates/v/atomecs.svg?style=flat)(https://crates.io/crates/atomecs)]
+[![crate_version](https://img.shields.io/badge/docs-latest-blue.svg?style=flat)(https://docs.rs/atomecs)]
 [![build](https://github.com/TeamAtomECS/AtomECS/actions/workflows/build.yml/badge.svg)](https://github.com/TeamAtomECS/AtomECS/actions/workflows/build.yml) [![unit_tests](https://github.com/TeamAtomECS/AtomECS/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/TeamAtomECS/AtomECS/actions/workflows/unit-tests.yml)
 
 `atomecs` is a rust crate for simulating ultracold atom experiments. It supports numerous features:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AtomECS
 > Simulate cold atoms with rust.
  
-<div align="center">
+<div align="left">
 <!-- Crates version -->
 <a href="https://crates.io/crates/atomecs">
 <img src="https://img.shields.io/crates/v/atomecs.svg?style=flat"

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 
 **New:** Paper out now on [arxiv](https://arxiv.org/abs/2105.06447)
 
-[![crate_version](https://img.shields.io/crates/v/atomecs.svg?style=flat)(https://crates.io/crates/atomecs)]
-[![crate_version](https://img.shields.io/badge/docs-latest-blue.svg?style=flat)(https://docs.rs/atomecs)]
+[![crate_version](https://img.shields.io/crates/v/atomecs.svg?style=flat)](https://crates.io/crates/atomecs)
+[![crate_version](https://img.shields.io/badge/docs-latest-blue.svg?style=flat)](https://docs.rs/atomecs)
 [![build](https://github.com/TeamAtomECS/AtomECS/actions/workflows/build.yml/badge.svg)](https://github.com/TeamAtomECS/AtomECS/actions/workflows/build.yml) [![unit_tests](https://github.com/TeamAtomECS/AtomECS/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/TeamAtomECS/AtomECS/actions/workflows/unit-tests.yml)
 
 `atomecs` is a rust crate for simulating ultracold atom experiments. It supports numerous features:

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # AtomECS
 > Simulate cold atoms with rust.
  
-//! <div align="center">
-//! <!-- Crates version -->
-//! <a href="https://crates.io/crates/atomecs">
-//! <img src="https://img.shields.io/crates/v/atomecs.svg?style=flat"
-//! alt="Crates.io version" />
-//! </a>
-//! <!-- docs.rs docs -->
-//! <a href="https://docs.rs/atomecs">
-//! <img src="https://img.shields.io/badge/docs-latest-blue.svg?style=flat"
-//! alt="docs.rs docs" />
-//! </a>
-//! </div>
+<div align="center">
+<!-- Crates version -->
+<a href="https://crates.io/crates/atomecs">
+<img src="https://img.shields.io/crates/v/atomecs.svg?style=flat"
+alt="Crates.io version" />
+</a>
+<!-- docs.rs docs -->
+<a href="https://docs.rs/atomecs">
+<img src="https://img.shields.io/badge/docs-latest-blue.svg?style=flat"
+alt="docs.rs docs" />
+</a>
+</div>
 
 **New:** Paper out now on [arxiv](https://arxiv.org/abs/2105.06447)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # AtomECS
 > Simulate cold atoms with rust.
  
+//! <div align="center">
+//! <!-- Crates version -->
+//! <a href="https://crates.io/crates/atomecs">
+//! <img src="https://img.shields.io/crates/v/atomecs.svg?style=flat"
+//! alt="Crates.io version" />
+//! </a>
+//! <!-- docs.rs docs -->
+//! <a href="https://docs.rs/atomecs">
+//! <img src="https://img.shields.io/badge/docs-latest-blue.svg?style=flat"
+//! alt="docs.rs docs" />
+//! </a>
+//! </div>
+
 **New:** Paper out now on [arxiv](https://arxiv.org/abs/2105.06447)
 
 [![build](https://github.com/TeamAtomECS/AtomECS/actions/workflows/build.yml/badge.svg)](https://github.com/TeamAtomECS/AtomECS/actions/workflows/build.yml) [![unit_tests](https://github.com/TeamAtomECS/AtomECS/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/TeamAtomECS/AtomECS/actions/workflows/unit-tests.yml)

--- a/src/magnetic/quadrupole.rs
+++ b/src/magnetic/quadrupole.rs
@@ -15,9 +15,9 @@ use specs::{Component, HashMapStorage, Join, ReadStorage, System, WriteStorage};
 #[derive(Serialize, Clone, Copy, Lerp)]
 pub struct QuadrupoleField3D {
     /// Gradient of the quadrupole field, in units of Tesla/m
-    gradient: f64,
+    pub gradient: f64,
     /// A unit vector pointing along the symmetry axis of the 3D quadrupole field.
-    direction: Vector3<f64>,
+    pub direction: Vector3<f64>,
 }
 impl QuadrupoleField3D {
     /// Creates a `QuadrupoleField3D` component with gradient specified in Gauss per cm.
@@ -128,13 +128,13 @@ impl<'a> System<'a> for Sample3DQuadrupoleFieldSystem {
 ///  * `e_y` is in the direction `direction_in`.
 pub struct QuadrupoleField2D {
     /// Gradient of the quadrupole field, `B'`, in units of Tesla/m
-    gradient: f64,
+    pub gradient: f64,
 
     /// A unit vector that defines the direction along which the field lines point away from the node. Perpendicular to `axis` and `direction_in`.
-    direction_out: Vector3<f64>,
+    pub direction_out: Vector3<f64>,
 
     /// A unit vector that defines the direction along which the field lines point in from the node. Perpendicular to both `direction_out` and `axis`.
-    direction_in: Vector3<f64>,
+    pub direction_in: Vector3<f64>,
 }
 impl QuadrupoleField2D {
     /// Creates a `QuadrupoleField2D` component with gradient specified in Gauss/cm.


### PR DESCRIPTION
This is so that the `QuadrupoleField3D` and `QuadrupoleField2D` are consistent with other magnetic field structs by having their fields public.