### PR TITLE
Const generics num of laser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,7 @@ dependencies = [
  "rand_distr",
  "rayon",
  "serde",
+ "serde_arrays",
  "serde_json",
  "serde_yaml",
  "specs",
@@ -750,6 +751,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_arrays"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38636132857f68ec3d5f3eb121166d2af33cb55174c4d5ff645db6165cbef0fd"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ csv = "1.1"
 byteorder = "1.3.2"
 multimap = "0.8.2"
 hashbrown = { version = "0.11.2", features = ["rayon"] }
+serde_arrays = "0.1.0"
 
 [dev-dependencies]
 gnuplot="0.0.37"

--- a/README.md
+++ b/README.md
@@ -1,21 +1,10 @@
 # AtomECS
 > Simulate cold atoms with rust.
- 
-<div align="left">
-<!-- Crates version -->
-<a href="https://crates.io/crates/atomecs">
-<img src="https://img.shields.io/crates/v/atomecs.svg?style=flat"
-alt="Crates.io version" />
-</a>
-<!-- docs.rs docs -->
-<a href="https://docs.rs/atomecs">
-<img src="https://img.shields.io/badge/docs-latest-blue.svg?style=flat"
-alt="docs.rs docs" />
-</a>
-</div>
 
 **New:** Paper out now on [arxiv](https://arxiv.org/abs/2105.06447)
 
+[![crate_version](https://img.shields.io/crates/v/atomecs.svg?style=flat)(https://crates.io/crates/atomecs)]
+[![crate_version](https://img.shields.io/badge/docs-latest-blue.svg?style=flat)(https://docs.rs/atomecs)]
 [![build](https://github.com/TeamAtomECS/AtomECS/actions/workflows/build.yml/badge.svg)](https://github.com/TeamAtomECS/AtomECS/actions/workflows/build.yml) [![unit_tests](https://github.com/TeamAtomECS/AtomECS/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/TeamAtomECS/AtomECS/actions/workflows/unit-tests.yml)
 
 `atomecs` is a rust crate for simulating ultracold atom experiments. It supports numerous features:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AtomECS
 > Simulate cold atoms with rust.
  
-<div align="center">
+<div align="left">
 <!-- Crates version -->
 <a href="https://crates.io/crates/atomecs">
 <img src="https://img.shields.io/crates/v/atomecs.svg?style=flat"

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 
 **New:** Paper out now on [arxiv](https://arxiv.org/abs/2105.06447)
 
-[![crate_version](https://img.shields.io/crates/v/atomecs.svg?style=flat)(https://crates.io/crates/atomecs)]
-[![crate_version](https://img.shields.io/badge/docs-latest-blue.svg?style=flat)(https://docs.rs/atomecs)]
+[![crate_version](https://img.shields.io/crates/v/atomecs.svg?style=flat)](https://crates.io/crates/atomecs)
+[![crate_version](https://img.shields.io/badge/docs-latest-blue.svg?style=flat)](https://docs.rs/atomecs)
 [![build](https://github.com/TeamAtomECS/AtomECS/actions/workflows/build.yml/badge.svg)](https://github.com/TeamAtomECS/AtomECS/actions/workflows/build.yml) [![unit_tests](https://github.com/TeamAtomECS/AtomECS/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/TeamAtomECS/AtomECS/actions/workflows/unit-tests.yml)
 
 `atomecs` is a rust crate for simulating ultracold atom experiments. It supports numerous features:

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # AtomECS
 > Simulate cold atoms with rust.
  
-//! <div align="center">
-//! <!-- Crates version -->
-//! <a href="https://crates.io/crates/atomecs">
-//! <img src="https://img.shields.io/crates/v/atomecs.svg?style=flat"
-//! alt="Crates.io version" />
-//! </a>
-//! <!-- docs.rs docs -->
-//! <a href="https://docs.rs/atomecs">
-//! <img src="https://img.shields.io/badge/docs-latest-blue.svg?style=flat"
-//! alt="docs.rs docs" />
-//! </a>
-//! </div>
+<div align="center">
+<!-- Crates version -->
+<a href="https://crates.io/crates/atomecs">
+<img src="https://img.shields.io/crates/v/atomecs.svg?style=flat"
+alt="Crates.io version" />
+</a>
+<!-- docs.rs docs -->
+<a href="https://docs.rs/atomecs">
+<img src="https://img.shields.io/badge/docs-latest-blue.svg?style=flat"
+alt="docs.rs docs" />
+</a>
+</div>
 
 **New:** Paper out now on [arxiv](https://arxiv.org/abs/2105.06447)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # AtomECS
 > Simulate cold atoms with rust.
  
+//! <div align="center">
+//! <!-- Crates version -->
+//! <a href="https://crates.io/crates/atomecs">
+//! <img src="https://img.shields.io/crates/v/atomecs.svg?style=flat"
+//! alt="Crates.io version" />
+//! </a>
+//! <!-- docs.rs docs -->
+//! <a href="https://docs.rs/atomecs">
+//! <img src="https://img.shields.io/badge/docs-latest-blue.svg?style=flat"
+//! alt="docs.rs docs" />
+//! </a>
+//! </div>
+
 **New:** Paper out now on [arxiv](https://arxiv.org/abs/2105.06447)
 
 [![build](https://github.com/TeamAtomECS/AtomECS/actions/workflows/build.yml/badge.svg)](https://github.com/TeamAtomECS/AtomECS/actions/workflows/build.yml) [![unit_tests](https://github.com/TeamAtomECS/AtomECS/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/TeamAtomECS/AtomECS/actions/workflows/unit-tests.yml)

--- a/benches/rate_calculation.rs
+++ b/benches/rate_calculation.rs
@@ -7,10 +7,10 @@ use lib::atom::{Atom, AtomicTransition, Force, Mass, Position, Velocity};
 use lib::ecs;
 use lib::initiate::NewlyCreated;
 use lib::integrator::Timestep;
-use lib::laser_cooling::CoolingLight;
 use lib::laser::gaussian::GaussianBeam;
 use lib::laser_cooling::force::EmissionForceOption;
 use lib::laser_cooling::photons_scattered::ScatteringFluctuationsOption;
+use lib::laser_cooling::CoolingLight;
 use lib::magnetic::quadrupole::QuadrupoleField3D;
 use nalgebra::Vector3;
 use rand_distr::{Distribution, Normal};
@@ -21,7 +21,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut world = World::new();
     ecs::register_components(&mut world);
     ecs::register_resources(&mut world);
-    let mut dispatcher = ecs::create_simulation_dispatcher_builder().build();
+    let mut dispatcher =
+        ecs::create_simulation_dispatcher_builder::<{ lib::laser::DEFAULT_BEAM_LIMIT }>().build();
     dispatcher.setup(&mut world);
 
     // Create magnetic field.
@@ -184,7 +185,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     // Now bench just a specific system.
     let mut bench_builder = DispatcherBuilder::new();
     bench_builder.add(
-        lib::laser_cooling::rate::CalculateRateCoefficientsSystem,
+        lib::laser_cooling::rate::CalculateRateCoefficientsSystem::<
+            { lib::laser::DEFAULT_BEAM_LIMIT },
+        >,
         "",
         &[],
     );

--- a/examples/1d_mot.rs
+++ b/examples/1d_mot.rs
@@ -20,7 +20,8 @@ fn main() {
     let mut world = World::new();
     ecs::register_components(&mut world);
     ecs::register_resources(&mut world);
-    let mut builder = ecs::create_simulation_dispatcher_builder();
+    let mut builder =
+        ecs::create_simulation_dispatcher_builder::<{ lib::laser::DEFAULT_BEAM_LIMIT }>();
 
     // Add some output to the simulation
     builder = builder.with(

--- a/examples/2d_plus_mot_from_oven.rs
+++ b/examples/2d_plus_mot_from_oven.rs
@@ -31,7 +31,8 @@ fn main() {
     let mut world = World::new();
     ecs::register_components(&mut world);
     ecs::register_resources(&mut world);
-    let mut builder = ecs::create_simulation_dispatcher_builder();
+    let mut builder =
+        ecs::create_simulation_dispatcher_builder::<{ lib::laser::DEFAULT_BEAM_LIMIT }>();
 
     // Configure simulation output.
     builder = builder.with(

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -53,7 +53,8 @@ fn main() {
     let mut world = World::new();
     ecs::register_components(&mut world);
     ecs::register_resources(&mut world);
-    let mut builder = ecs::create_simulation_dispatcher_builder();
+    let mut builder =
+        ecs::create_simulation_dispatcher_builder::<{ lib::laser::DEFAULT_BEAM_LIMIT }>();
 
     // Configure thread pool.
     let pool = rayon::ThreadPoolBuilder::new()

--- a/examples/cross_section.rs
+++ b/examples/cross_section.rs
@@ -18,11 +18,15 @@ fn main() {
     let mut world = World::new();
     ecs::register_components(&mut world);
     ecs::register_resources(&mut world);
-    let mut builder = ecs::create_simulation_dispatcher_builder();
+    let mut builder =
+        ecs::create_simulation_dispatcher_builder::<{ lib::laser::DEFAULT_BEAM_LIMIT }>();
 
     // Output scattering rate and velocity
     builder = builder.with(
-        file::new::<ExpectedPhotonsScatteredVector, Text>("scattered.txt".to_string(), 1),
+        file::new::<ExpectedPhotonsScatteredVector<{ lib::laser::DEFAULT_BEAM_LIMIT }>, Text>(
+            "scattered.txt".to_string(),
+            1,
+        ),
         "",
         &[],
     );

--- a/examples/dipole_trap.rs
+++ b/examples/dipole_trap.rs
@@ -22,7 +22,8 @@ fn main() {
     let mut world = World::new();
     ecs::register_components(&mut world);
     ecs::register_resources(&mut world);
-    let mut builder = ecs::create_simulation_dispatcher_builder();
+    let mut builder =
+        ecs::create_simulation_dispatcher_builder::<{ lib::laser::DEFAULT_BEAM_LIMIT }>();
 
     // Configure simulation output.
     builder = builder.with(
@@ -60,9 +61,7 @@ fn main() {
     world
         .create_entity()
         .with(gaussian_beam)
-        .with(dipole::DipoleLight {
-            wavelength,
-        })
+        .with(dipole::DipoleLight { wavelength })
         .with(laser::frame::Frame {
             x_vector: Vector3::y(),
             y_vector: Vector3::z(),
@@ -80,9 +79,7 @@ fn main() {
     world
         .create_entity()
         .with(gaussian_beam)
-        .with(dipole::DipoleLight {
-            wavelength,
-        })
+        .with(dipole::DipoleLight { wavelength })
         .with(laser::frame::Frame {
             x_vector: Vector3::x(),
             y_vector: Vector3::z(),

--- a/examples/doppler_limit.rs
+++ b/examples/doppler_limit.rs
@@ -60,7 +60,8 @@ fn main() {
     let mut world = World::new();
     ecs::register_components(&mut world);
     ecs::register_resources(&mut world);
-    let mut builder = ecs::create_simulation_dispatcher_builder();
+    let mut builder =
+        ecs::create_simulation_dispatcher_builder::<{ lib::laser::DEFAULT_BEAM_LIMIT }>();
 
     // Configure simulation output.
     builder = builder.with(

--- a/examples/molasses_1d.rs
+++ b/examples/molasses_1d.rs
@@ -16,7 +16,8 @@ fn main() {
     let mut world = World::new();
     ecs::register_components(&mut world);
     ecs::register_resources(&mut world);
-    let mut builder = ecs::create_simulation_dispatcher_builder();
+    let mut builder =
+        ecs::create_simulation_dispatcher_builder::<{ lib::laser::DEFAULT_BEAM_LIMIT }>();
 
     // Add some output to the simulation
     builder = builder.with(
@@ -26,7 +27,10 @@ fn main() {
     );
 
     builder = builder.with(
-        file::new::<ActualPhotonsScatteredVector, Text>("scattered.txt".to_string(), 10),
+        file::new::<ActualPhotonsScatteredVector<{ lib::laser::DEFAULT_BEAM_LIMIT }>, Text>(
+            "scattered.txt".to_string(),
+            10,
+        ),
         "",
         &[],
     );

--- a/examples/quadrupole_trap.rs
+++ b/examples/quadrupole_trap.rs
@@ -28,7 +28,7 @@ fn main() {
     world.register::<MagneticDipole>();
     let mut atomecs_builder = AtomecsDispatcherBuilder::new();
     atomecs_builder.add_frame_initialisation_systems();
-    atomecs_builder.add_systems();
+    atomecs_builder.add_systems::<{ lib::laser::DEFAULT_BEAM_LIMIT }>();
     atomecs_builder.builder.add(
         ApplyMagneticForceSystem {},
         "magnetic_force",

--- a/examples/recoil_limit.rs
+++ b/examples/recoil_limit.rs
@@ -62,7 +62,8 @@ fn main() {
     let mut world = World::new();
     ecs::register_components(&mut world);
     ecs::register_resources(&mut world);
-    let mut builder = ecs::create_simulation_dispatcher_builder();
+    let mut builder =
+        ecs::create_simulation_dispatcher_builder::<{ lib::laser::DEFAULT_BEAM_LIMIT }>();
 
     // Configure simulation output.
     builder = builder.with(

--- a/examples/top_trap_with_collisions.rs
+++ b/examples/top_trap_with_collisions.rs
@@ -32,7 +32,7 @@ fn main() {
     world.register::<TimeOrbitingPotential>();
     let mut atomecs_builder = AtomecsDispatcherBuilder::new();
     atomecs_builder.add_frame_initialisation_systems();
-    atomecs_builder.add_systems();
+    atomecs_builder.add_systems::<{ lib::laser::DEFAULT_BEAM_LIMIT }>();
     atomecs_builder.builder.add(
         ApplyMagneticForceSystem {},
         "magnetic_force",

--- a/src/collisions.rs
+++ b/src/collisions.rs
@@ -263,9 +263,7 @@ fn pos_to_id(pos: Vector3<f64>, n: i64, width: f64) -> i64 {
     let bound = (n as f64) / 2.0 * width;
 
     let id: i64;
-    if pos[0].abs() > bound
-        || pos[1].abs() > bound
-        || pos[2].abs() > bound {
+    if pos[0].abs() > bound || pos[1].abs() > bound || pos[2].abs() > bound {
         id = i64::MAX;
     } else {
         let xp: i64;
@@ -407,7 +405,7 @@ pub mod tests {
         test_world.register::<NewlyCreated>();
         let mut atomecs_builder = AtomecsDispatcherBuilder::new();
         atomecs_builder.add_frame_initialisation_systems();
-        atomecs_builder.add_systems();
+        atomecs_builder.add_systems::<{ crate::laser::DEFAULT_BEAM_LIMIT }>();
         atomecs_builder
             .builder
             .add(ApplyCollisionsSystem, "collisions", &[]);

--- a/src/dipole/mod.rs
+++ b/src/dipole/mod.rs
@@ -60,9 +60,7 @@ impl Polarizability {
             / (2. * (2. * constant::PI * transition_f).powf(3.0))
             * optical_transition_linewidth
             * -(1. / (transition_f - dipole_f) + 1. / (transition_f + dipole_f));
-        Polarizability {
-            prefactor,
-        }
+        Polarizability { prefactor }
     }
 }
 
@@ -90,9 +88,12 @@ impl<'a> System<'a> for AttachIndexToDipoleLightSystem {
 /// `builder`: the dispatch builder to modify
 ///
 /// `deps`: any dependencies that must be completed before the systems run.
-pub fn add_systems_to_dispatch(builder: &mut DispatcherBuilder<'static, 'static>, deps: &[&str]) {
+pub fn add_systems_to_dispatch<const N: usize>(
+    builder: &mut DispatcherBuilder<'static, 'static>,
+    deps: &[&str],
+) {
     builder.add(
-        force::ApplyDipoleForceSystem,
+        force::ApplyDipoleForceSystem::<N>,
         "apply_dipole_force",
         &["sample_intensity_gradient"],
     );

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -49,7 +49,7 @@ impl AtomecsDispatcherBuilder {
 
     pub fn add_frame_initialisation_systems(&mut self) {}
 
-    pub fn add_systems(&mut self) {
+    pub fn add_systems<const N: usize>(&mut self) {
         self.builder.add(
             VelocityVerletIntegratePositionSystem,
             INTEGRATE_POSITION_SYSTEM_NAME,
@@ -61,9 +61,9 @@ impl AtomecsDispatcherBuilder {
         self.builder.add(AddOldForceToNewAtomsSystem, "", &[]);
 
         magnetic::add_systems_to_dispatch(&mut self.builder, &[]);
-        laser::add_systems_to_dispatch(&mut self.builder, &[]);
-        laser_cooling::add_systems_to_dispatch(&mut self.builder, &[]);
-        dipole::add_systems_to_dispatch(&mut self.builder, &[]);
+        laser::add_systems_to_dispatch::<N>(&mut self.builder, &[]);
+        laser_cooling::add_systems_to_dispatch::<N>(&mut self.builder, &[]);
+        dipole::add_systems_to_dispatch::<N>(&mut self.builder, &[]);
         atom_sources::add_systems_to_dispatch(&mut self.builder, &[]);
         self.builder.add(
             ApplyGravitationalForceSystem,
@@ -93,23 +93,24 @@ impl AtomecsDispatcherBuilder {
         sim_region::add_systems_to_dispatch(&mut self.builder, &[]);
     }
 
-    pub fn build(mut self) -> DispatcherBuilder<'static, 'static> {
+    pub fn build<const N: usize>(mut self) -> DispatcherBuilder<'static, 'static> {
         self.add_frame_initialisation_systems();
-        self.add_systems();
+        self.add_systems::<N>();
         self.add_frame_end_systems();
         self.builder
     }
 }
 
 /// Creates a [Dispatcher](specs::Dispatcher) that is used to calculate each simulation frame.
-pub fn create_simulation_dispatcher() -> Dispatcher<'static, 'static> {
-    let builder = create_simulation_dispatcher_builder();
+pub fn create_simulation_dispatcher<const N: usize>() -> Dispatcher<'static, 'static> {
+    let builder = create_simulation_dispatcher_builder::<N>();
     builder.build()
 }
 
-pub fn create_simulation_dispatcher_builder() -> DispatcherBuilder<'static, 'static> {
+pub fn create_simulation_dispatcher_builder<const N: usize>() -> DispatcherBuilder<'static, 'static>
+{
     let atomecs_builder = AtomecsDispatcherBuilder::new();
-    atomecs_builder.build()
+    atomecs_builder.build::<N>()
 }
 
 /// Add required resources to the world

--- a/src/integration_tests/rate_equation.rs
+++ b/src/integration_tests/rate_equation.rs
@@ -10,6 +10,7 @@ pub mod tests {
     use crate::integrator::Timestep;
     use crate::laser::gaussian::GaussianBeam;
     use crate::laser::index::LaserIndex;
+    use crate::laser::DEFAULT_BEAM_LIMIT;
     use crate::laser_cooling::photons_scattered::TotalPhotonsScattered;
     use crate::laser_cooling::CoolingLight;
     extern crate nalgebra;
@@ -48,17 +49,14 @@ pub mod tests {
         // Create simulation dispatcher
         ecs::register_components(&mut world);
         ecs::register_resources(&mut world);
-        let mut dispatcher = ecs::create_simulation_dispatcher_builder().build();
+        let mut dispatcher =
+            ecs::create_simulation_dispatcher_builder::<{DEFAULT_BEAM_LIMIT}>().build();
         dispatcher.setup(&mut world);
 
         // add laser to test world.
         world
             .create_entity()
-            .with(CoolingLight::for_species(
-                transition,
-                detuning_megahz,
-                1,
-            ))
+            .with(CoolingLight::for_species(transition, detuning_megahz, 1))
             .with(LaserIndex::default())
             .with(GaussianBeam::from_peak_intensity_with_rayleigh_range(
                 Vector3::new(0.0, 0.0, 0.0),

--- a/src/laser/intensity_gradient.rs
+++ b/src/laser/intensity_gradient.rs
@@ -29,11 +29,12 @@ impl Default for LaserIntensityGradientSampler {
 }
 
 /// Component that holds a list of `LaserIntensityGradientSampler`s
-pub struct LaserIntensityGradientSamplers {
+pub struct LaserIntensityGradientSamplers<const N: usize> {
     /// List of laser gradient samplers
-    pub contents: [LaserIntensityGradientSampler; crate::laser::BEAM_LIMIT],
+    pub contents: [LaserIntensityGradientSampler; N],
 }
-impl Component for LaserIntensityGradientSamplers {
+
+impl<const N: usize> Component for LaserIntensityGradientSamplers<N> {
     type Storage = VecStorage<Self>;
 }
 
@@ -44,15 +45,16 @@ impl Component for LaserIntensityGradientSamplers {
 /// `Frame` to account for different ellipiticies in the future.
 /// The result is stored in the `LaserIntensityGradientSamplers` component that each
 /// atom is associated with.
-pub struct SampleGaussianLaserIntensityGradientSystem;
-impl<'a> System<'a> for SampleGaussianLaserIntensityGradientSystem {
+pub struct SampleGaussianLaserIntensityGradientSystem<const N: usize>;
+
+impl<'a, const N: usize> System<'a> for SampleGaussianLaserIntensityGradientSystem<N> {
     type SystemData = (
         ReadStorage<'a, DipoleLight>,
         ReadStorage<'a, LaserIndex>,
         ReadStorage<'a, GaussianBeam>,
         ReadStorage<'a, Frame>,
         ReadStorage<'a, Position>,
-        WriteStorage<'a, LaserIntensityGradientSamplers>,
+        WriteStorage<'a, LaserIntensityGradientSamplers<N>>,
     );
 
     fn run(
@@ -73,6 +75,8 @@ impl<'a> System<'a> for SampleGaussianLaserIntensityGradientSystem {
 }
 #[cfg(test)]
 pub mod tests {
+    use crate::laser::DEFAULT_BEAM_LIMIT;
+
     use super::*;
 
     extern crate specs;
@@ -88,7 +92,7 @@ pub mod tests {
         test_world.register::<LaserIndex>();
         test_world.register::<GaussianBeam>();
         test_world.register::<Position>();
-        test_world.register::<LaserIntensityGradientSamplers>();
+        test_world.register::<LaserIntensityGradientSamplers<{ DEFAULT_BEAM_LIMIT }>>();
         test_world.register::<Frame>();
         test_world.register::<DipoleLight>();
 
@@ -126,13 +130,15 @@ pub mod tests {
                 pos: Vector3::new(10.0e-6, 0.0, 30.0e-6),
             })
             .with(LaserIntensityGradientSamplers {
-                contents: [LaserIntensityGradientSampler::default(); crate::laser::BEAM_LIMIT],
+                contents: [LaserIntensityGradientSampler::default();
+                    crate::laser::DEFAULT_BEAM_LIMIT],
             })
             .build();
-        let mut system = SampleGaussianLaserIntensityGradientSystem;
+        let mut system = SampleGaussianLaserIntensityGradientSystem::<{ DEFAULT_BEAM_LIMIT }>;
         system.run_now(&test_world);
         test_world.maintain();
-        let sampler_storage = test_world.read_storage::<LaserIntensityGradientSamplers>();
+        let sampler_storage =
+            test_world.read_storage::<LaserIntensityGradientSamplers<{ DEFAULT_BEAM_LIMIT }>>();
         let sim_result_gradient = sampler_storage
             .get(atom1)
             .expect("Entity not found!")
@@ -174,7 +180,7 @@ pub mod tests {
         test_world.register::<LaserIndex>();
         test_world.register::<GaussianBeam>();
         test_world.register::<Position>();
-        test_world.register::<LaserIntensityGradientSamplers>();
+        test_world.register::<LaserIntensityGradientSamplers<{ DEFAULT_BEAM_LIMIT }>>();
         test_world.register::<Frame>();
         test_world.register::<DipoleLight>();
 
@@ -212,13 +218,15 @@ pub mod tests {
                 pos: Vector3::new(20.0e-6, 20.0e-6, 20.0e-6),
             })
             .with(LaserIntensityGradientSamplers {
-                contents: [LaserIntensityGradientSampler::default(); crate::laser::BEAM_LIMIT],
+                contents: [LaserIntensityGradientSampler::default();
+                    crate::laser::DEFAULT_BEAM_LIMIT],
             })
             .build();
-        let mut system = SampleGaussianLaserIntensityGradientSystem;
+        let mut system = SampleGaussianLaserIntensityGradientSystem::<{ DEFAULT_BEAM_LIMIT }>;
         system.run_now(&test_world);
         test_world.maintain();
-        let sampler_storage = test_world.read_storage::<LaserIntensityGradientSamplers>();
+        let sampler_storage =
+            test_world.read_storage::<LaserIntensityGradientSamplers<{ DEFAULT_BEAM_LIMIT }>>();
         let sim_result_gradient = sampler_storage
             .get(atom1)
             .expect("Entity not found!")

--- a/src/laser/sampler.rs
+++ b/src/laser/sampler.rs
@@ -14,35 +14,37 @@ pub struct LaserSamplerMask {
     pub filled: bool,
 }
 /// Component that holds a vector of `LaserSamplerMask`
-pub struct CoolingLaserSamplerMasks {
+pub struct CoolingLaserSamplerMasks<const N: usize> {
     /// List of `LaserSamplerMask`s
-    pub contents: [LaserSamplerMask; crate::laser::BEAM_LIMIT],
+    pub contents: [LaserSamplerMask; N],
 }
-impl Component for CoolingLaserSamplerMasks {
+impl<const N: usize> Component for CoolingLaserSamplerMasks<N> {
     type Storage = VecStorage<Self>;
 }
 
 /// Marks all laser sampler mask slots as empty.
-pub struct InitialiseLaserSamplerMasksSystem;
-impl<'a> System<'a> for InitialiseLaserSamplerMasksSystem {
-    type SystemData = (WriteStorage<'a, CoolingLaserSamplerMasks>,);
+pub struct InitialiseLaserSamplerMasksSystem<const N: usize>;
+
+impl<'a, const N: usize> System<'a> for InitialiseLaserSamplerMasksSystem<N> {
+    type SystemData = (WriteStorage<'a, CoolingLaserSamplerMasks<N>>,);
 
     fn run(&mut self, (mut masks,): Self::SystemData) {
         use rayon::prelude::*;
 
         (&mut masks).par_join().for_each(|mask| {
-            mask.contents = [LaserSamplerMask::default(); crate::laser::BEAM_LIMIT];
+            mask.contents = [LaserSamplerMask::default(); N];
         });
     }
 }
 
 /// Determines which laser sampler slots are currently being used.
-pub struct FillLaserSamplerMasksSystem;
-impl<'a> System<'a> for FillLaserSamplerMasksSystem {
+pub struct FillLaserSamplerMasksSystem<const N: usize>;
+
+impl<'a, const N: usize> System<'a> for FillLaserSamplerMasksSystem<N> {
     type SystemData = (
         ReadStorage<'a, LaserIndex>,
         ReadStorage<'a, CoolingLight>,
-        WriteStorage<'a, CoolingLaserSamplerMasks>,
+        WriteStorage<'a, CoolingLaserSamplerMasks<N>>,
     );
     fn run(&mut self, (light_index, cooling, mut masks): Self::SystemData) {
         use rayon::prelude::*;

--- a/src/laser_cooling/rate.rs
+++ b/src/laser_cooling/rate.rs
@@ -30,27 +30,30 @@ impl Default for RateCoefficient {
 
 /// Component that holds a Vector of `RateCoefficient`
 #[derive(Clone, Copy, Serialize)]
-pub struct RateCoefficients {
+pub struct RateCoefficients<const N: usize> {
     /// Vector of `RateCoefficient` where each entry corresponds to a different CoolingLight entity
-    pub contents: [RateCoefficient; crate::laser::BEAM_LIMIT],
+    #[serde(with = "serde_arrays")]
+    pub contents: [RateCoefficient; N],
 }
-impl Component for RateCoefficients {
+
+impl<const N: usize> Component for RateCoefficients<N> {
     type Storage = VecStorage<Self>;
 }
 
 /// This system initialises all `RateCoefficient` to a NAN value.
 ///
 /// It also ensures that the size of the `RateCoefficient` components match the number of CoolingLight entities in the world.
-pub struct InitialiseRateCoefficientsSystem;
-impl<'a> System<'a> for InitialiseRateCoefficientsSystem {
-    type SystemData = (WriteStorage<'a, RateCoefficients>,);
+pub struct InitialiseRateCoefficientsSystem<const N: usize>;
+
+impl<'a, const N: usize> System<'a> for InitialiseRateCoefficientsSystem<N> {
+    type SystemData = (WriteStorage<'a, RateCoefficients<N>>,);
     fn run(&mut self, (mut rate_coefficients,): Self::SystemData) {
         use rayon::prelude::*;
 
         (&mut rate_coefficients)
             .par_join()
             .for_each(|mut rate_coefficient| {
-                rate_coefficient.contents = [RateCoefficient::default(); crate::laser::BEAM_LIMIT];
+                rate_coefficient.contents = [RateCoefficient::default(); N];
             });
     }
 }
@@ -63,18 +66,18 @@ impl<'a> System<'a> for InitialiseRateCoefficientsSystem {
 /// This is also the System that currently takes care of handling the polarizations correctly.
 /// The polarization is projected onto the quantization axis given by the local magnetic
 /// field vector. For fully polarized CoolingLight all projection pre-factors add up to 1.
-pub struct CalculateRateCoefficientsSystem;
+pub struct CalculateRateCoefficientsSystem<const N: usize>;
 
-impl<'a> System<'a> for CalculateRateCoefficientsSystem {
+impl<'a, const N: usize> System<'a> for CalculateRateCoefficientsSystem<N> {
     type SystemData = (
         ReadStorage<'a, CoolingLight>,
         ReadStorage<'a, LaserIndex>,
-        ReadStorage<'a, LaserDetuningSamplers>,
-        ReadStorage<'a, LaserIntensitySamplers>,
+        ReadStorage<'a, LaserDetuningSamplers<N>>,
+        ReadStorage<'a, LaserIntensitySamplers<N>>,
         ReadStorage<'a, AtomicTransition>,
         ReadStorage<'a, GaussianBeam>,
         ReadStorage<'a, MagneticFieldSampler>,
-        WriteStorage<'a, RateCoefficients>,
+        WriteStorage<'a, RateCoefficients<N>>,
     );
     fn run(
         &mut self,
@@ -139,6 +142,7 @@ pub mod tests {
     use super::*;
 
     use crate::laser::index::LaserIndex;
+    use crate::laser::DEFAULT_BEAM_LIMIT;
     use crate::laser_cooling::CoolingLight;
     use assert_approx_eq::assert_approx_eq;
     extern crate nalgebra;
@@ -156,11 +160,11 @@ pub mod tests {
         test_world.register::<LaserIndex>();
         test_world.register::<CoolingLight>();
         test_world.register::<GaussianBeam>();
-        test_world.register::<LaserDetuningSamplers>();
-        test_world.register::<LaserIntensitySamplers>();
+        test_world.register::<LaserDetuningSamplers<{ DEFAULT_BEAM_LIMIT }>>();
+        test_world.register::<LaserIntensitySamplers<{ DEFAULT_BEAM_LIMIT }>>();
         test_world.register::<AtomicTransition>();
         test_world.register::<MagneticFieldSampler>();
-        test_world.register::<RateCoefficients>();
+        test_world.register::<RateCoefficients<{ DEFAULT_BEAM_LIMIT }>>();
 
         let wavelength = 461e-9;
         test_world
@@ -194,12 +198,11 @@ pub mod tests {
                     detuning_sigma_plus: detuning,
                     detuning_sigma_minus: detuning,
                     detuning_pi: detuning,
-                }; crate::laser::BEAM_LIMIT],
+                }; crate::laser::DEFAULT_BEAM_LIMIT],
             })
             .with(LaserIntensitySamplers {
-                contents: [crate::laser::intensity::LaserIntensitySampler {
-                    intensity,
-                }; crate::laser::BEAM_LIMIT],
+                contents: [crate::laser::intensity::LaserIntensitySampler { intensity };
+                    crate::laser::DEFAULT_BEAM_LIMIT],
             })
             .with(AtomicTransition::strontium())
             .with(MagneticFieldSampler {
@@ -209,14 +212,14 @@ pub mod tests {
                 jacobian: Matrix3::zeros(),
             })
             .with(RateCoefficients {
-                contents: [RateCoefficient::default(); crate::laser::BEAM_LIMIT],
+                contents: [RateCoefficient::default(); crate::laser::DEFAULT_BEAM_LIMIT],
             })
             .build();
 
-        let mut system = CalculateRateCoefficientsSystem;
+        let mut system = CalculateRateCoefficientsSystem::<{ DEFAULT_BEAM_LIMIT }>;
         system.run_now(&test_world);
         test_world.maintain();
-        let sampler_storage = test_world.read_storage::<RateCoefficients>();
+        let sampler_storage = test_world.read_storage::<RateCoefficients<{ DEFAULT_BEAM_LIMIT }>>();
 
         let man_pref = AtomicTransition::strontium().rate_prefactor * intensity;
         let scatter1 = 0.25 * man_pref

--- a/src/magnetic/quadrupole.rs
+++ b/src/magnetic/quadrupole.rs
@@ -15,9 +15,9 @@ use specs::{Component, HashMapStorage, Join, ReadStorage, System, WriteStorage};
 #[derive(Serialize, Clone, Copy, Lerp)]
 pub struct QuadrupoleField3D {
     /// Gradient of the quadrupole field, in units of Tesla/m
-    gradient: f64,
+    pub gradient: f64,
     /// A unit vector pointing along the symmetry axis of the 3D quadrupole field.
-    direction: Vector3<f64>,
+    pub direction: Vector3<f64>,
 }
 impl QuadrupoleField3D {
     /// Creates a `QuadrupoleField3D` component with gradient specified in Gauss per cm.
@@ -128,13 +128,13 @@ impl<'a> System<'a> for Sample3DQuadrupoleFieldSystem {
 ///  * `e_y` is in the direction `direction_in`.
 pub struct QuadrupoleField2D {
     /// Gradient of the quadrupole field, `B'`, in units of Tesla/m
-    gradient: f64,
+    pub gradient: f64,
 
     /// A unit vector that defines the direction along which the field lines point away from the node. Perpendicular to `axis` and `direction_in`.
-    direction_out: Vector3<f64>,
+    pub direction_out: Vector3<f64>,
 
     /// A unit vector that defines the direction along which the field lines point in from the node. Perpendicular to both `direction_out` and `axis`.
-    direction_in: Vector3<f64>,
+    pub direction_in: Vector3<f64>,
 }
 impl QuadrupoleField2D {
     /// Creates a `QuadrupoleField2D` component with gradient specified in Gauss/cm.


### PR DESCRIPTION
The fixed length arrays that had length of `BEAM_LIMIT` now have the length specified with constant generics, which is eventually exposed to the user when creating the builder.